### PR TITLE
Allow custom path to appsettings.json

### DIFF
--- a/Xero.Api/ApplicationSettings.cs
+++ b/Xero.Api/ApplicationSettings.cs
@@ -7,10 +7,10 @@ namespace Xero.Api
     {
         public IConfigurationSection ApiSettings { get; set; }
 
-        public ApplicationSettings()
+        public ApplicationSettings(string path = "appsettings.json")
         {
             var builder = new ConfigurationBuilder()
-                .AddJsonFile("appsettings.json")
+                .AddJsonFile(path)
                 .Build();
 
             ApiSettings = builder.GetSection("XeroApi");

--- a/Xero.Api/ApplicationSettings.cs
+++ b/Xero.Api/ApplicationSettings.cs
@@ -7,13 +7,16 @@ namespace Xero.Api
     {
         public IConfigurationSection ApiSettings { get; set; }
 
-        public ApplicationSettings(string path = "appsettings.json")
+        public ApplicationSettings(string path)
         {
             var builder = new ConfigurationBuilder()
                 .AddJsonFile(path)
                 .Build();
 
             ApiSettings = builder.GetSection("XeroApi");
+        }
+        public ApplicationSettings() : this("appsettings.json")
+        {
         }
 
         public string BaseUrl => ApiSettings["BaseUrl"];

--- a/Xero.Api/Core/XeroCoreApi.cs
+++ b/Xero.Api/Core/XeroCoreApi.cs
@@ -23,7 +23,7 @@ namespace Xero.Api.Core
         }
 
         public XeroCoreApi(IAuthenticator auth, IUser user = null, IRateLimiter rateLimiter = null)
-            : base(auth, new ApplicationSettings(), user, rateLimiter)
+            : this(auth, new ApplicationSettings(), user, rateLimiter)
         {
             Connect();
         }

--- a/Xero.Api/Core/XeroCoreApi.cs
+++ b/Xero.Api/Core/XeroCoreApi.cs
@@ -14,18 +14,16 @@ namespace Xero.Api.Core
 {
     public class XeroCoreApi : XeroApi, IXeroCoreApi
     {
-        protected static readonly ApplicationSettings ApplicationSettings = new ApplicationSettings();
-        
         private IOrganisationEndpoint OrganisationEndpoint { get; set; }
-        
-        public XeroCoreApi(IAuthenticator auth, IUser user = null, IRateLimiter rateLimiter = null)
-            : base(ApplicationSettings.BaseUrl, auth, new Consumer(ApplicationSettings.Key, ApplicationSettings.Secret), user, rateLimiter)
+
+        public XeroCoreApi(IAuthenticator auth,ApplicationSettings applicationSettings, IUser user = null, IRateLimiter rateLimiter = null)
+            : base(applicationSettings.BaseUrl, auth, new Consumer(applicationSettings.Key, applicationSettings.Secret), user, rateLimiter)
         {
             Connect();
         }
 
-        public XeroCoreApi(IAuthenticator auth,ApplicationSettings applicationSettings, IUser user = null, IRateLimiter rateLimiter = null)
-            : base(applicationSettings.BaseUrl, auth, new Consumer(applicationSettings.Key, applicationSettings.Secret), user, rateLimiter)
+        public XeroCoreApi(IAuthenticator auth, IUser user = null, IRateLimiter rateLimiter = null)
+            : base(auth, new ApplicationSettings(), user, rateLimiter)
         {
             Connect();
         }

--- a/Xero.Api/Core/XeroCoreApi.cs
+++ b/Xero.Api/Core/XeroCoreApi.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Xero.Api.Common;
@@ -14,7 +14,7 @@ namespace Xero.Api.Core
 {
     public class XeroCoreApi : XeroApi, IXeroCoreApi
     {
-        private static readonly ApplicationSettings ApplicationSettings = new ApplicationSettings();
+        protected static readonly ApplicationSettings ApplicationSettings = new ApplicationSettings();
         
         private IOrganisationEndpoint OrganisationEndpoint { get; set; }
         


### PR DESCRIPTION
This change makes it possible to use a configuration file other than "appsettings.json"

Since the `XeroCoreApi` class requires an instance of `ApplicationSettings`, its impossible to instantiate one for use without the constructor firing which raises an Exception when "appsettings.json" doesn't exist.