### PR TITLE
Makes PartnerApp() static otherwise it cannot be used.

### DIFF
--- a/Xero.Api.Example.Console/Program.cs
+++ b/Xero.Api.Example.Console/Program.cs
@@ -36,7 +36,7 @@ namespace Xero.Api.Example.Console
             };
         }
 
-        private IXeroCoreApi PartnerApp()
+        private static IXeroCoreApi PartnerApp()
         {
             var tokenStore = new MemoryTokenStore();
             var user = new ApiUser { Identifier = Environment.MachineName };


### PR DESCRIPTION
@MatthewMXero 

Only changes the examples therefore no need to do a release