### PR TITLE
Added AppliedAmount field to Prepayment and Overpayment

### DIFF
--- a/Xero.Api/Core/Model/Overpayment.cs
+++ b/Xero.Api/Core/Model/Overpayment.cs
@@ -46,6 +46,9 @@ namespace Xero.Api.Core.Model
         [DataMember(EmitDefaultValue = false)]
         public OverpaymentType Type { get; set; }
 
+        [DataMember(EmitDefaultValue = false)]
+        public decimal? AppliedAmount { get; set; }
+
         [DataMember]
         public Decimal RemainingCredit { get; set; }
 

--- a/Xero.Api/Core/Model/Prepayment.cs
+++ b/Xero.Api/Core/Model/Prepayment.cs
@@ -46,6 +46,9 @@ namespace Xero.Api.Core.Model
         [DataMember]
         public PrepaymentType Type { get; set; }
 
+        [DataMember(EmitDefaultValue = false)]
+        public decimal? AppliedAmount { get; set; }
+
         [DataMember]
         public Decimal RemainingCredit { get; set; }
 


### PR DESCRIPTION
At the moment I can't determine how much has been credited from each Overpayment and Prepayment against an invoice by using the api client.
A manual request to the invoice api endpoint shows there is an "AppliedAmount" field for Prepayments and Overpayments, but they need to be added to the model to be accessible from the api client. Credit Notes linked to an invoice also have the field, but it's already included in the model so no change is required there.