### PR TITLE
Do not add null parameters when quering Profit&Loss

### DIFF
--- a/CoreTests/Integration/Reports/Find.cs
+++ b/CoreTests/Integration/Reports/Find.cs
@@ -24,14 +24,35 @@ namespace CoreTests.Integration.Reports
         [Test]
         public async Task find_profit_loss_report()
         {
-            var reports = await Api.Reports.ProfitAndLossAsync(DateTime.Now.AddDays(-50));
+            var reports = await Api.Reports.ProfitAndLossAsync(DateTime.Now);
             Assert.IsNotNull(reports);
         }
 
         [Test]
         public async Task find_budget_summary_report()
         {
-            var reports = await Api.Reports.BudgetSummaryAsync(DateTime.Now.AddDays(-50));
+            var reports = await Api.Reports.BudgetSummaryAsync(DateTime.Now);
+            Assert.IsNotNull(reports);
+        }
+        
+        [Test]
+        public async Task find_bank_summary_report()
+        {
+            var reports = await Api.Reports.BankSummaryAsync();
+            Assert.IsNotNull(reports);
+        }
+
+        [Test]
+        public async Task find_executive_summary_report()
+        {
+            var reports = await Api.Reports.ExecutiveSummaryAsync(DateTime.Now);
+            Assert.IsNotNull(reports);
+        }
+
+        [Test]
+        public async Task find_trial_balance_report()
+        {
+            var reports = await Api.Reports.TrailBalanceAsync(DateTime.Now);
             Assert.IsNotNull(reports);
         }
     }

--- a/CoreTests/Integration/Reports/Find.cs
+++ b/CoreTests/Integration/Reports/Find.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading.Tasks;
 using NUnit.Framework;
 
 namespace CoreTests.Integration.Reports
@@ -6,32 +7,31 @@ namespace CoreTests.Integration.Reports
     [TestFixture]
     public class Find : ApiWrapperTest
     {
-
         [Test]
-        public void find_all()
+        public async Task find_all()
         {
-            var reports = Api.Reports.FindAsync();
+            var reports = await Api.Reports.FindAsync();
             Assert.IsNotNull(reports);
         }
 
         [Test]
-        public void find_gst_report()
+        public async Task find_balance_sheet_report()
         {
-            var reports = Api.Reports.FindAsync("BalanceSheet");
+            var reports = await Api.Reports.BalanceSheetAsync(DateTime.Now);
             Assert.IsNotNull(reports);
         }
 
         [Test]
-        public void find_PL_report()
+        public async Task find_profit_loss_report()
         {
-            var reports = Api.Reports.ProfitAndLossAsync(DateTime.Now.AddDays(-50));
+            var reports = await Api.Reports.ProfitAndLossAsync(DateTime.Now.AddDays(-50));
             Assert.IsNotNull(reports);
         }
 
         [Test]
-        public void find_BudgetSummary_report()
+        public async Task find_budget_summary_report()
         {
-            var reports = Api.Reports.BudgetSummaryAsync(DateTime.Now.AddDays(-50));
+            var reports = await Api.Reports.BudgetSummaryAsync(DateTime.Now.AddDays(-50));
             Assert.IsNotNull(reports);
         }
     }

--- a/Xero.Api/Common/Extensions.cs
+++ b/Xero.Api/Common/Extensions.cs
@@ -36,5 +36,13 @@ namespace Xero.Api.Common
                 collection.Add(name, value.Value.ToString("yyyy-MM-dd"));
             }
         }
+
+        public static void AddIfNotNull(this NameValueCollection collection, string name, string value)
+        {
+            if (value != null)
+            {
+                collection.Add(name, value.ToLower());
+            }
+        }
     }
 }

--- a/Xero.Api/Common/Extensions.cs
+++ b/Xero.Api/Common/Extensions.cs
@@ -3,9 +3,9 @@ using System.Collections.Specialized;
 
 namespace Xero.Api.Common
 {
-    public static class Extensions
+    internal static class Extensions
     {
-        public static void Add(this NameValueCollection collection, string name, Guid? value)
+        public static void AddIfNotNull(this NameValueCollection collection, string name, Guid? value)
         {
             if (value.HasValue)
             {
@@ -13,7 +13,7 @@ namespace Xero.Api.Common
             }
         }
 
-        public static void Add(this NameValueCollection collection, string name, int? value)
+        public static void AddIfNotNull(this NameValueCollection collection, string name, int? value)
         {
             if (value.HasValue)
             {
@@ -21,11 +21,19 @@ namespace Xero.Api.Common
             }
         }
 
-        public static void Add(this NameValueCollection collection, string name, bool? value)
+        public static void AddIfNotNull(this NameValueCollection collection, string name, bool? value)
         {
             if (value.HasValue)
             {
                 collection.Add(name, value.Value.ToString().ToLower());
+            }
+        }
+
+        public static void AddIfNotNull(this NameValueCollection collection, string name, DateTime? value)
+        {
+            if (value.HasValue)
+            {
+                collection.Add(name, value.Value.ToString("yyyy-MM-dd"));
             }
         }
     }

--- a/Xero.Api/Core/Endpoints/AttachmentsEndpoint.cs
+++ b/Xero.Api/Core/Endpoints/AttachmentsEndpoint.cs
@@ -51,7 +51,7 @@ namespace Xero.Api.Core.Endpoints
 
             if (SupportsOnline(type) && includeOnline)
             {
-                parameters.Add("IncludeOnline", true);
+                parameters.AddIfNotNull("IncludeOnline", true);
             }
 
             var result = await Client.PostAsync<Attachment, AttachmentsResponse>(url, attachment.Content, mimeType, parameters);

--- a/Xero.Api/Core/Endpoints/ReportsEndpoint.cs
+++ b/Xero.Api/Core/Endpoints/ReportsEndpoint.cs
@@ -64,7 +64,7 @@ namespace Xero.Api.Core.Endpoints
         {
             var parameters = new NameValueCollection();
 
-            parameters.AddYear("reportYear", year);
+            parameters.AddIfNotNull("reportYear", year?.Year);
 
             var endpoint = AddParameters(parameters);
 
@@ -94,13 +94,13 @@ namespace Xero.Api.Core.Endpoints
         {
             var parameters = new NameValueCollection();
 
-            parameters.Add("date", date);
-            parameters.Add("trackingOptionID1", tracking1);
-            parameters.Add("trackingOptionID2", tracking2);
-            parameters.Add("standardLayout", standardLayout);
-            parameters.Add("paymentsOnly", paymentsOnly);
+            parameters.AddIfNotNull("date", date);
+            parameters.AddIfNotNull("trackingOptionID1", tracking1);
+            parameters.AddIfNotNull("trackingOptionID2", tracking2);
+            parameters.AddIfNotNull("standardLayout", standardLayout);
+            parameters.AddIfNotNull("paymentsOnly", paymentsOnly);
             parameters.Add("timeframe", timeframe);
-            parameters.Add("periods", periods);
+            parameters.AddIfNotNull("periods", periods);
             
             var endpoint = AddParameters(parameters);
 
@@ -111,9 +111,9 @@ namespace Xero.Api.Core.Endpoints
         {
             var parameters = new NameValueCollection();
 
-            parameters.Add("bankAccountID", account);
-            parameters.Add("fromDate", from);
-            parameters.Add("toDate", to);
+            parameters.AddIfNotNull("bankAccountID", account);
+            parameters.AddIfNotNull("fromDate", from);
+            parameters.AddIfNotNull("toDate", to);
 
             var endpoint = AddParameters(parameters);
 
@@ -124,8 +124,8 @@ namespace Xero.Api.Core.Endpoints
         {
             var parameters = new NameValueCollection();
 
-            parameters.Add("fromDate", from);
-            parameters.Add("toDate", to);
+            parameters.AddIfNotNull("fromDate", from);
+            parameters.AddIfNotNull("toDate", to);
 
             var endpoint = AddParameters(parameters);
 
@@ -136,9 +136,9 @@ namespace Xero.Api.Core.Endpoints
         {
             var parameters = new NameValueCollection();
 
-            parameters.Add("date", date);
-            parameters.Add("periods", periods);
-            parameters.Add("timeframe", (int?)timeFrame);
+            parameters.AddIfNotNull("date", date);
+            parameters.AddIfNotNull("periods", periods);
+            parameters.AddIfNotNull("timeframe", (int?)timeFrame);
 
             var endpoint = AddParameters(parameters);
 
@@ -149,7 +149,7 @@ namespace Xero.Api.Core.Endpoints
         {
             var parameters = new NameValueCollection();
 
-            parameters.Add("date", date);
+            parameters.AddIfNotNull("date", date);
 
             var endpoint = AddParameters(parameters);
 
@@ -162,17 +162,17 @@ namespace Xero.Api.Core.Endpoints
         {
             var parameters = new NameValueCollection();
 
-            parameters.Add("date", date);
-            parameters.Add("fromDate", from);
-            parameters.Add("toDate", to);
-            parameters.Add("trackingCategoryID", trackingCategory);
-            parameters.Add("trackingOptionID", trackingOption);
-            parameters.Add("trackingCategoryID2", trackingCategory2);
-            parameters.Add("trackingOptionID2", trackingOption2);
-            parameters.Add("standardLayout", standardLayout);
-            parameters.Add("paymentsOnly", paymentsOnly);
+            parameters.AddIfNotNull("date", date);
+            parameters.AddIfNotNull("fromDate", from);
+            parameters.AddIfNotNull("toDate", to);
+            parameters.AddIfNotNull("trackingCategoryID", trackingCategory);
+            parameters.AddIfNotNull("trackingOptionID", trackingOption);
+            parameters.AddIfNotNull("trackingCategoryID2", trackingCategory2);
+            parameters.AddIfNotNull("trackingOptionID2", trackingOption2);
+            parameters.AddIfNotNull("standardLayout", standardLayout);
+            parameters.AddIfNotNull("paymentsOnly", paymentsOnly);
             parameters.Add("timeframe", timeframe);
-            parameters.Add("periods", periods);
+            parameters.AddIfNotNull("periods", periods);
 
             var endpoint = AddParameters(parameters);
 
@@ -183,8 +183,8 @@ namespace Xero.Api.Core.Endpoints
         {
             var parameters = new NameValueCollection();
 
-            parameters.Add("date", date);
-            parameters.Add("paymentsOnly", paymentsOnly);
+            parameters.AddIfNotNull("date", date);
+            parameters.AddIfNotNull("paymentsOnly", paymentsOnly);
 
             var endpoint = AddParameters(parameters);
 
@@ -193,42 +193,14 @@ namespace Xero.Api.Core.Endpoints
 
         private NameValueCollection GetAgedParameters(Guid contact, DateTime? date, DateTime? from, DateTime? to)
         {
-            var parameters = new NameValueCollection
-            {
-                {
-                    "contactID", contact.ToString("D")
-                }
-            };
+            var parameters = new NameValueCollection();
 
-            parameters.Add("date", date);
-            parameters.Add("fromDate", from);
-            parameters.Add("toDate", to);
+            parameters.AddIfNotNull("contactID", contact);
+            parameters.AddIfNotNull("date", date);
+            parameters.AddIfNotNull("fromDate", from);
+            parameters.AddIfNotNull("toDate", to);
 
             return parameters;
-        }
-    }
-
-    internal static class Extensions
-    {
-        public static string ToReportDate(this DateTime dt)
-        {
-            return dt.ToString("yyyy-MM-dd");
-        }
-
-        public static void AddYear(this NameValueCollection collection, string name, DateTime? value)
-        {
-            if (value.HasValue)
-            {
-                collection.Add(name, value.Value.Year);
-            }
-        }
-
-        public static void Add(this NameValueCollection collection, string name, DateTime? value)
-        {
-            if (value.HasValue)
-            {
-                collection.Add(name, value.Value.ToReportDate());
-            }
         }
     }
 }

--- a/Xero.Api/Core/Endpoints/ReportsEndpoint.cs
+++ b/Xero.Api/Core/Endpoints/ReportsEndpoint.cs
@@ -99,7 +99,7 @@ namespace Xero.Api.Core.Endpoints
             parameters.AddIfNotNull("trackingOptionID2", tracking2);
             parameters.AddIfNotNull("standardLayout", standardLayout);
             parameters.AddIfNotNull("paymentsOnly", paymentsOnly);
-            parameters.Add("timeframe", timeframe);
+            parameters.AddIfNotNull("timeframe", timeframe);
             parameters.AddIfNotNull("periods", periods);
             
             var endpoint = AddParameters(parameters);
@@ -171,7 +171,7 @@ namespace Xero.Api.Core.Endpoints
             parameters.AddIfNotNull("trackingOptionID2", trackingOption2);
             parameters.AddIfNotNull("standardLayout", standardLayout);
             parameters.AddIfNotNull("paymentsOnly", paymentsOnly);
-            parameters.Add("timeframe", timeframe);
+            parameters.AddIfNotNull("timeframe", timeframe);
             parameters.AddIfNotNull("periods", periods);
 
             var endpoint = AddParameters(parameters);


### PR DESCRIPTION
It seems I'm the first one who tried to call Profit&Loss via new SDK 😄 .

There are `NameValueCollection.Add()` extensions for different nullable types which adds only when value is not null, but there was not any extension for `string`, so the default implementation of `Add()` method was used. When [QueryGenerator.UrlEncodedQueryString](https://github.com/XeroAPI/Xero-NetStandard/blob/794d9d6c85436e78507ed393e7933902de8f687b/Xero.Api/Common/QueryGenerator.cs#L30-L37) is used, `Uri.EscapeDataString` throws an exception if one of the parameters values is null. 

There are two ways two fix it:
1. Change `QueryGenerator.UrlEncodedQueryString` so it ignores null values.
2. Add `NameValueCollection.AddIfNotNull()` extension for string values.

I chose the second one, since the first one might affect some logic in other API calls.

So I did the following changes:

1. Renamed all `Add()` extensions to `AddIfNotNull()`. Yes, it doesn't look such elegant, but the name clearly describes what the method does and it avoids any future confusion.
2. Made [Xero.Api.Common.Extensions](https://github.com/XeroAPI/Xero-NetStandard/blob/794d9d6c85436e78507ed393e7933902de8f687b/Xero.Api/Common/Extensions.cs#L6) internal. I believe it's a bad practice to make any internal extensions to be public in libraries.
3. Tests for reports was not working. It was not async. That's why they passed well. Now it's fixed.
4. Added missing reports tests.

Not sure if `collection.AddIfNotNull()` can be used here, since it checks string on empty not just null.
https://github.com/XeroAPI/Xero-NetStandard/blob/794d9d6c85436e78507ed393e7933902de8f687b/Xero.Api/Common/QueryGenerator.cs#L39-L58