### PR TITLE
Adding ConfigureAwait(false)

### DIFF
--- a/Xero.Api/Common/XeroReadEndpoint.cs
+++ b/Xero.Api/Common/XeroReadEndpoint.cs
@@ -76,17 +76,17 @@ namespace Xero.Api.Common
 
         public virtual async Task<IEnumerable<TResult>> FindAsync()
         {
-            return await GetAsync(ApiEndpointUrl, null);
+            return await GetAsync(ApiEndpointUrl, null).ConfigureAwait(false);
         }
 
         public virtual async Task<TResult> FindAsync(Guid child)
         {
-            return await FindAsync(child.ToString("D"));
+            return await FindAsync(child.ToString("D")).ConfigureAwait(false);
         }
 
         public async Task<TResult> FindAsync(string child)
         {
-            var results = await GetAsync(ApiEndpointUrl, "/" + child);
+            var results = await GetAsync(ApiEndpointUrl, "/" + child).ConfigureAwait(false);
 
             return results.FirstOrDefault();
         }
@@ -170,7 +170,7 @@ namespace Xero.Api.Common
             try
             {
                 endpoint = endpoint + (child ?? string.Empty);
-                return await Client.GetAsync<TResult, TResponse>(endpoint, Parameters, _query, _orderBy, _modifiedSince);
+                return await Client.GetAsync<TResult, TResponse>(endpoint, Parameters, _query, _orderBy, _modifiedSince).ConfigureAwait(false);
             }
             finally
             {

--- a/Xero.Api/Core/Endpoints/AllocationEndpoint.cs
+++ b/Xero.Api/Core/Endpoints/AllocationEndpoint.cs
@@ -22,27 +22,27 @@ namespace Xero.Api.Core.Endpoints
         {
             var endpoint = string.Format("/api.xro/2.0/CreditNotes/{0}/Allocations", allocation.CreditNote.Id);
 
-            return await AddAsync(allocation, endpoint) as CreditNoteAllocation;
+            return await AddAsync(allocation, endpoint).ConfigureAwait(false) as CreditNoteAllocation;
         }
 
         public async Task<PrepaymentAllocation> AddAsync(PrepaymentAllocation allocation)
         {
             var endpoint = string.Format("/api.xro/2.0/Prepayments/{0}/Allocations", allocation.Prepayment.Id);
 
-            return await AddAsync(allocation, endpoint) as PrepaymentAllocation;
+            return await AddAsync(allocation, endpoint).ConfigureAwait(false) as PrepaymentAllocation;
         }
 
         public async Task<OverpaymentAllocation> AddAsync(OverpaymentAllocation allocation)
         {
             var endpoint = string.Format("/api.xro/2.0/Overpayments/{0}/Allocations", allocation.Overpayment.Id);
 
-            return await AddAsync(allocation, endpoint) as OverpaymentAllocation;
+            return await AddAsync(allocation, endpoint).ConfigureAwait(false) as OverpaymentAllocation;
         }
 
         private async Task<AllocationsResponse<T>> HandleResponseAsync<T>(HttpResponseMessage response)
             where T : AllocationBase
         {
-            var body = await response.Content.ReadAsStringAsync();
+            var body = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
 
             if (response.StatusCode == HttpStatusCode.OK)
             {
@@ -50,7 +50,7 @@ namespace Xero.Api.Core.Endpoints
                 return result;
             }
 
-            await _client.HandleErrorsAsync(response);
+            await _client.HandleErrorsAsync(response).ConfigureAwait(false);
 
             return null;
         }
@@ -58,9 +58,9 @@ namespace Xero.Api.Core.Endpoints
         public async Task<AllocationBase> AddAsync<T>(T allocation, string endpoint)
             where T : AllocationBase
         {
-            var response = await _client.PutAsync(endpoint, new List<T> {allocation});
+            var response = await _client.PutAsync(endpoint, new List<T> {allocation}).ConfigureAwait(false);
 
-            var result = await HandleResponseAsync<T>(response);
+            var result = await HandleResponseAsync<T>(response).ConfigureAwait(false);
 
             return result.Allocations.FirstOrDefault();
         }

--- a/Xero.Api/Core/Endpoints/AssociationsEndpoint.cs
+++ b/Xero.Api/Core/Endpoints/AssociationsEndpoint.cs
@@ -34,46 +34,46 @@ namespace Xero.Api.Core.Endpoints
         {
             var endpoint = string.Format("files.xro/1.0/Files/{0}/Associations/{1}", fileId, objectId);
 
-            var response = await Client.GetAsync(endpoint, null);
+            var response = await Client.GetAsync(endpoint, null).ConfigureAwait(false);
 
-            return await HandleAssociationResponseAsync(response);
+            return await HandleAssociationResponseAsync(response).ConfigureAwait(false);
         }
 
         public async Task<IEnumerable<Association>> FindAsync(Guid fileId)
         {
             var endpoint = string.Format("files.xro/1.0/Files/{0}/Associations", fileId);
-            var response = await Client.GetAsync(endpoint, null);
+            var response = await Client.GetAsync(endpoint, null).ConfigureAwait(false);
 
-            return await HandleAssociationsResponseAsync(response);
+            return await HandleAssociationsResponseAsync(response).ConfigureAwait(false);
         }
 
         public async Task<IEnumerable<Association>> FindForObjectAsync(Guid objectId)
         {
             var endpoint = string.Format("files.xro/1.0/Associations/{0}", objectId);
-            var response = await Client.GetAsync(endpoint, null);
+            var response = await Client.GetAsync(endpoint, null).ConfigureAwait(false);
 
-            return await HandleAssociationsResponseAsync(response);
+            return await HandleAssociationsResponseAsync(response).ConfigureAwait(false);
         }
 
         public async Task<Association> CreateAsync(Association association)
         {
             var endpoint = string.Format("files.xro/1.0/Files/{0}/Associations", association.FileId);
-            var response = await Client.PostAsync(endpoint, association, true);
+            var response = await Client.PostAsync(endpoint, association, true).ConfigureAwait(false);
 
-            return await HandleAssociationResponseAsync(response);
+            return await HandleAssociationResponseAsync(response).ConfigureAwait(false);
         }
 
         public async Task DeleteAsync(Association association)
         {
             var endpoint = string.Format("files.xro/1.0/Files/{0}/Associations/{1}", association.FileId, association.ObjectId);
-            var response = await Client.DeleteAsync(endpoint);
+            var response = await Client.DeleteAsync(endpoint).ConfigureAwait(false);
 
-            await HandleAssociationResponseAsync(response);
+            await HandleAssociationResponseAsync(response).ConfigureAwait(false);
         }
 
         private async Task<IEnumerable<Association>> HandleAssociationsResponseAsync(HttpResponseMessage response)
         {
-            var body = await response.Content.ReadAsStringAsync();
+            var body = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
 
             if (response.StatusCode == HttpStatusCode.OK
                 || response.StatusCode == HttpStatusCode.Created
@@ -81,13 +81,13 @@ namespace Xero.Api.Core.Endpoints
             {
                 return Client.JsonMapper.From<IEnumerable<Association>>(body);
             }
-            await Client.HandleErrorsAsync(response);
+            await Client.HandleErrorsAsync(response).ConfigureAwait(false);
             return null;
         }
 
         private async Task<Association> HandleAssociationResponseAsync(HttpResponseMessage response)
         {
-            var body = await response.Content.ReadAsStringAsync();
+            var body = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
 
             if (response.StatusCode == HttpStatusCode.OK
                 || response.StatusCode == HttpStatusCode.Created
@@ -95,7 +95,7 @@ namespace Xero.Api.Core.Endpoints
             {
                 return Client.JsonMapper.From<Association>(body);
             }
-            await Client.HandleErrorsAsync(response);
+            await Client.HandleErrorsAsync(response).ConfigureAwait(false);
             return null;
         }
     }

--- a/Xero.Api/Core/Endpoints/AttachmentsEndpoint.cs
+++ b/Xero.Api/Core/Endpoints/AttachmentsEndpoint.cs
@@ -23,21 +23,21 @@ namespace Xero.Api.Core.Endpoints
 
         public async Task<IEnumerable<Attachment>> ListAsync(AttachmentEndpointType type, Guid parent)
         {
-            return await Client.GetAsync<Attachment, AttachmentsResponse>(string.Format("/api.xro/2.0/{0}/{1}/Attachments", type, parent.ToString("D")));
+            return await Client.GetAsync<Attachment, AttachmentsResponse>(string.Format("/api.xro/2.0/{0}/{1}/Attachments", type, parent.ToString("D"))).ConfigureAwait(false);
         }
 
         public async Task<Attachment> GetAsync(AttachmentEndpointType type, Guid parent, string fileName)
         {
-            var response = await Client.GetAsync(string.Format("/api.xro/2.0/{0}/{1}/Attachments/{2}", type, parent.ToString("D"), fileName));
+            var response = await Client.GetAsync(string.Format("/api.xro/2.0/{0}/{1}/Attachments/{2}", type, parent.ToString("D"), fileName)).ConfigureAwait(false);
 
             if (response.StatusCode == HttpStatusCode.OK)
             {
-                var stream = await response.Content.ReadAsStreamAsync();
+                var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
 
                 return new Attachment(stream, fileName, response.Content.Headers.ContentType.ToString(), (int)stream.Length);
             }
 
-            await Client.HandleErrorsAsync(response);
+            await Client.HandleErrorsAsync(response).ConfigureAwait(false);
             return null;
         }
 
@@ -54,7 +54,7 @@ namespace Xero.Api.Core.Endpoints
                 parameters.AddIfNotNull("IncludeOnline", true);
             }
 
-            var result = await Client.PostAsync<Attachment, AttachmentsResponse>(url, attachment.Content, mimeType, parameters);
+            var result = await Client.PostAsync<Attachment, AttachmentsResponse>(url, attachment.Content, mimeType, parameters).ConfigureAwait(false);
 
             return result.FirstOrDefault();
         }

--- a/Xero.Api/Core/Endpoints/Base/XeroCreateEndpoint.cs
+++ b/Xero.Api/Core/Endpoints/Base/XeroCreateEndpoint.cs
@@ -23,12 +23,12 @@ namespace Xero.Api.Core.Endpoints.Base
             var request = new TRequest();
             request.AddRange(items);
 
-            return await PutAsync(request);
+            return await PutAsync(request).ConfigureAwait(false);
         }
 
         public async Task<TResult> CreateAsync(TResult item)
         {
-            return (await CreateAsync(new[] { item })).First();
+            return (await CreateAsync(new[] { item }).ConfigureAwait(false)).First();
         }
 
         public T SummarizeErrors(bool summarize)
@@ -40,12 +40,12 @@ namespace Xero.Api.Core.Endpoints.Base
         {
             try
             {
-                return await Client.PutAsync<TResult, TResponse>(ApiEndpointUrl, data, Parameters);
+                return await Client.PutAsync<TResult, TResponse>(ApiEndpointUrl, data, Parameters).ConfigureAwait(false);
             }
             finally
             {
-                ClearQueryString();            
+                ClearQueryString();
             }
-        }        
+        }
     }
 }

--- a/Xero.Api/Core/Endpoints/Base/XeroUpdateEndpoint.cs
+++ b/Xero.Api/Core/Endpoints/Base/XeroUpdateEndpoint.cs
@@ -15,7 +15,7 @@ namespace Xero.Api.Core.Endpoints.Base
     {
         protected XeroUpdateEndpoint(XeroHttpClient client, string apiEndpointUrl)
             : base(client, apiEndpointUrl)
-        {            
+        {
         }
 
         public async Task<IEnumerable<TResult>> UpdateAsync(IEnumerable<TResult> items)
@@ -23,19 +23,19 @@ namespace Xero.Api.Core.Endpoints.Base
             var request = new TRequest();
             request.AddRange(items);
 
-            return await PostAsync(request);
+            return await PostAsync(request).ConfigureAwait(false);
         }
 
         public virtual async Task<TResult> UpdateAsync(TResult item)
         {
-            return (await UpdateAsync(new[] { item })).First();
+            return (await UpdateAsync(new[] { item }).ConfigureAwait(false)).First();
         }
 
         protected async Task<IEnumerable<TResult>> PostAsync(TRequest data)
         {
             try
             {
-                return await Client.PostAsync<TResult, TResponse>(ApiEndpointUrl, data, Parameters);
+                return await Client.PostAsync<TResult, TResponse>(ApiEndpointUrl, data, Parameters).ConfigureAwait(false);
             }
             finally
             {

--- a/Xero.Api/Core/Endpoints/ContactGroupEndpoint.cs
+++ b/Xero.Api/Core/Endpoints/ContactGroupEndpoint.cs
@@ -30,37 +30,37 @@ namespace Xero.Api.Core.Endpoints
         {
             var endpoint = string.Format("/api.xro/2.0/ContactGroups/{0}/Contacts", contactGroup.Id);
 
-            var response = await Client.DeleteAsync(endpoint);
+            var response = await Client.DeleteAsync(endpoint).ConfigureAwait(false);
 
-            await HandleResponseAsync(response);
+            await HandleResponseAsync(response).ConfigureAwait(false);
         }
 
         public async Task AddContactAsync(ContactGroup contactGroup, Contact contact)
         {
-            await AddContactsAsync(contactGroup, new List<Contact>{contact});
+            await AddContactsAsync(contactGroup, new List<Contact>{contact}).ConfigureAwait(false);
         }
 
         public async Task AddContactsAsync(ContactGroup contactGroup, List<Contact> contacts)
         {
             var endpoint = string.Format("/api.xro/2.0/ContactGroups/{0}/Contacts", contactGroup.Id);
 
-            var response = await Client.PutAsync(endpoint, contacts);
+            var response = await Client.PutAsync(endpoint, contacts).ConfigureAwait(false);
 
-            await HandleResponseAsync(response);
+            await HandleResponseAsync(response).ConfigureAwait(false);
         }
 
         public async Task RemoveContactAsync(ContactGroup contactGroup, Contact contact)
         {
             var endpoint = string.Format("/api.xro/2.0/ContactGroups/{0}/Contacts/{1}", contactGroup.Id, contact.Id);
 
-            var response = await Client.DeleteAsync(endpoint);
+            var response = await Client.DeleteAsync(endpoint).ConfigureAwait(false);
 
-            await HandleResponseAsync(response);
+            await HandleResponseAsync(response).ConfigureAwait(false);
         }
 
         private async Task<ContactGroupsResponse> HandleResponseAsync(HttpResponseMessage response)
         {
-            var body = await response.Content.ReadAsStringAsync();
+            var body = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
 
             if (response.StatusCode == HttpStatusCode.OK)
             {
@@ -68,7 +68,7 @@ namespace Xero.Api.Core.Endpoints
                 return result;
             }
 
-            await Client.HandleErrorsAsync(response);
+            await Client.HandleErrorsAsync(response).ConfigureAwait(false);
 
             return null;
         }

--- a/Xero.Api/Core/Endpoints/ContactsEndpoint.cs
+++ b/Xero.Api/Core/Endpoints/ContactsEndpoint.cs
@@ -41,7 +41,7 @@ namespace Xero.Api.Core.Endpoints
 
         public async Task<ContactCisSetting> GetCisSettingsAsync(Guid id)
         {
-            var contactCisSettings = await Client.GetAsync<ContactCisSetting, ContactCisSettingsResponse>($"/api.xro/2.0/contacts/{id}/cissettings");
+            var contactCisSettings = await Client.GetAsync<ContactCisSetting, ContactCisSettingsResponse>($"/api.xro/2.0/contacts/{id}/cissettings").ConfigureAwait(false);
 
             return contactCisSettings.FirstOrDefault();
         }

--- a/Xero.Api/Core/Endpoints/FilesEndpoint.cs
+++ b/Xero.Api/Core/Endpoints/FilesEndpoint.cs
@@ -37,17 +37,17 @@ namespace Xero.Api.Core.Endpoints
 
         public override async Task<IEnumerable<Model.File>> FindAsync()
         {
-            var response = await Client.GetAsync("files.xro/1.0/Files", QueryString);
+            var response = await Client.GetAsync("files.xro/1.0/Files", QueryString).ConfigureAwait(false);
 
-            var result = await HandleFilesResponseAsync(response);
+            var result = await HandleFilesResponseAsync(response).ConfigureAwait(false);
 
             return result.Items;
         }
 
         public override async Task<Model.File> FindAsync(Guid fileId)
         {
-            var response = await Client.GetAsync("files.xro/1.0/Files", "");
-            var result = await HandleFilesResponseAsync(response);
+            var response = await Client.GetAsync("files.xro/1.0/Files", "").ConfigureAwait(false);
+            var result = await HandleFilesResponseAsync(response).ConfigureAwait(false);
 
             return result.Items.SingleOrDefault(i => i.Id == fileId);
         }
@@ -59,8 +59,8 @@ namespace Xero.Api.Core.Endpoints
                 Name = name
             };
 
-            var response = await Client.PutAsync("files.xro/1.0/Files/" + id, file, true);
-            return await HandleFileResponseAsync(response);
+            var response = await Client.PutAsync("files.xro/1.0/Files/" + id, file, true).ConfigureAwait(false);
+            return await HandleFileResponseAsync(response).ConfigureAwait(false);
         }
 
         public async Task<Model.File> MoveAsync(Guid id, Guid newFolder)
@@ -70,27 +70,27 @@ namespace Xero.Api.Core.Endpoints
                 FolderId = newFolder
             };
 
-            var response = await Client.PutAsync("files.xro/1.0/Files/" + id, file, true); 
-            return await HandleFileResponseAsync(response);
+            var response = await Client.PutAsync("files.xro/1.0/Files/" + id, file, true).ConfigureAwait(false); 
+            return await HandleFileResponseAsync(response).ConfigureAwait(false);
         }
 
         public async Task<Model.File> AddAsync(Guid folderId, Model.File file, byte[] data)
         {
-            var response = await Client.PostMultipartFormAsync("files.xro/1.0/Files/" + folderId, file.Mimetype, file.Name, file.FileName, data);
-            return await HandleFileResponseAsync(response);
+            var response = await Client.PostMultipartFormAsync("files.xro/1.0/Files/" + folderId, file.Mimetype, file.Name, file.FileName, data).ConfigureAwait(false);
+            return await HandleFileResponseAsync(response).ConfigureAwait(false);
         }
 
         public async Task<Model.File> RemoveAsync(Guid fileid)
         {
-            var response = await Client.DeleteAsync("files.xro/1.0/Files/" + fileid);
-            return await HandleFileResponseAsync(response);
+            var response = await Client.DeleteAsync("files.xro/1.0/Files/" + fileid).ConfigureAwait(false);
+            return await HandleFileResponseAsync(response).ConfigureAwait(false);
         }
 
         public async Task<byte[]> GetContentAsync(Guid id, string contentType)
         {
-            var response = await Client.GetRawAsync("files.xro/1.0/Files/" + id + "/Content", contentType);
+            var response = await Client.GetRawAsync("files.xro/1.0/Files/" + id + "/Content", contentType).ConfigureAwait(false);
 
-            return await response.Content.ReadAsByteArrayAsync();
+            return await response.Content.ReadAsByteArrayAsync().ConfigureAwait(false);
 
         }
 
@@ -98,13 +98,13 @@ namespace Xero.Api.Core.Endpoints
         {
             if (response.StatusCode == HttpStatusCode.OK || response.StatusCode == HttpStatusCode.Created)
             {
-                var body = await response.Content.ReadAsStringAsync();
+                var body = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
 
                 var result = Client.JsonMapper.From<Model.File>(body);
                 return result;
             }
 
-            await Client.HandleErrorsAsync(response);
+            await Client.HandleErrorsAsync(response).ConfigureAwait(false);
 
             return null;
         }
@@ -113,13 +113,13 @@ namespace Xero.Api.Core.Endpoints
         {
             if (response.StatusCode == HttpStatusCode.OK || response.StatusCode == HttpStatusCode.Created)
             {
-                var body = await response.Content.ReadAsStringAsync();
+                var body = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
 
                 var result = Client.JsonMapper.From<FilesResponse>(body);
                 return result;
             }
 
-            await Client.HandleErrorsAsync(response);
+            await Client.HandleErrorsAsync(response).ConfigureAwait(false);
 
             return null;
         }

--- a/Xero.Api/Core/Endpoints/FoldersEndpoint.cs
+++ b/Xero.Api/Core/Endpoints/FoldersEndpoint.cs
@@ -32,15 +32,15 @@ namespace Xero.Api.Core.Endpoints
     {
         var endpoint = "files.xro/1.0/Folders";
 
-        var response = await Client.PostAsync(endpoint, new Folder{Name = folderName}, true);
+        var response = await Client.PostAsync(endpoint, new Folder{Name = folderName}, true).ConfigureAwait(false);
 
-        return await HandleFolderResponseAsync(response);
+        return await HandleFolderResponseAsync(response).ConfigureAwait(false);
     }
 
     public new async Task<IEnumerable<Folder>> FindAsync()
     {
-        var response = await Client.GetAsync("files.xro/1.0/Folders", "");
-        var result = await HandleFoldersResponseAsync(response);
+        var response = await Client.GetAsync("files.xro/1.0/Folders", "").ConfigureAwait(false);
+        var result = await HandleFoldersResponseAsync(response).ConfigureAwait(false);
 
 
       var resultingFolders = from i in result
@@ -51,8 +51,8 @@ namespace Xero.Api.Core.Endpoints
 
     public async Task RemoveAsync(Guid id)
     {
-        var response = await Client.DeleteAsync("files.xro/1.0/Folders/" + id);
-        await HandleFolderResponseAsync(response);
+        var response = await Client.DeleteAsync("files.xro/1.0/Folders/" + id).ConfigureAwait(false);
+        await HandleFolderResponseAsync(response).ConfigureAwait(false);
     }
 
     public async Task<FoldersResponse> RenameAsync(Guid id, string name)
@@ -62,8 +62,8 @@ namespace Xero.Api.Core.Endpoints
            Name = name
        };
 
-        var response = await Client.PutAsync("files.xro/1.0/Folders/" + id, folder, true);
-        var result =  await HandleFoldersResponseAsync(response);
+        var response = await Client.PutAsync("files.xro/1.0/Folders/" + id, folder, true).ConfigureAwait(false);
+        var result =  await HandleFoldersResponseAsync(response).ConfigureAwait(false);
         return result?[0];
     }
 
@@ -71,14 +71,14 @@ namespace Xero.Api.Core.Endpoints
     {
       if (response.StatusCode == HttpStatusCode.OK || response.StatusCode == HttpStatusCode.Created)
       {
-        var body = await response.Content.ReadAsStringAsync();
+        var body = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
 
         var result = Client.JsonMapper.From<FilePageResponse>(body);
 
         return result;
       }
 
-      await Client.HandleErrorsAsync(response);
+      await Client.HandleErrorsAsync(response).ConfigureAwait(false);
 
       return null;
     }
@@ -87,14 +87,14 @@ namespace Xero.Api.Core.Endpoints
     {
       if (response.StatusCode == HttpStatusCode.OK)
       {
-        var body = await response.Content.ReadAsStringAsync();
+        var body = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
 
         var result = Client.JsonMapper.From<FoldersResponse[]>(body);
 
         return result;
       }
 
-      await Client.HandleErrorsAsync(response);
+      await Client.HandleErrorsAsync(response).ConfigureAwait(false);
 
       return null;
     }

--- a/Xero.Api/Core/Endpoints/HistoryAndNotesEndpoint.cs
+++ b/Xero.Api/Core/Endpoints/HistoryAndNotesEndpoint.cs
@@ -27,14 +27,14 @@ namespace Xero.Api.Core.Endpoints
 
         public async Task<IEnumerable<HistoryRecord>> FindAsync(HistoryAndNotesEndpointRetrieveType type, Guid parent)
         {
-            return await Client.GetAsync<HistoryRecord, HistoryRecordsResponse>($"api.xro/2.0/{type}/{parent:D}/history");
+            return await Client.GetAsync<HistoryRecord, HistoryRecordsResponse>($"api.xro/2.0/{type}/{parent:D}/history").ConfigureAwait(false);
         }
 
         public async Task<HistoryRecord> CreateNoteAsync(HistoryAndNotesEndpointCreateType type, Guid parent, HistoryRecord note)
         {
             var request = new HistoryRecordsRequest{note};
 
-            var historyRecords = await Client.PutAsync<HistoryRecord, HistoryRecordsResponse>($"api.xro/2.0/{type}/{parent:D}/history", request);
+            var historyRecords = await Client.PutAsync<HistoryRecord, HistoryRecordsResponse>($"api.xro/2.0/{type}/{parent:D}/history", request).ConfigureAwait(false);
             return historyRecords.FirstOrDefault();
         }
     }

--- a/Xero.Api/Core/Endpoints/InboxEndpoint.cs
+++ b/Xero.Api/Core/Endpoints/InboxEndpoint.cs
@@ -28,9 +28,9 @@ namespace Xero.Api.Core.Endpoints
         {
             var endpoint = "files.xro/1.0/Inbox";
 
-            var response = await Client.GetAsync(endpoint, null);
+            var response = await Client.GetAsync(endpoint, null).ConfigureAwait(false);
 
-            var folder = await HandleFoldersResponseAsync(response);
+            var folder = await HandleFoldersResponseAsync(response).ConfigureAwait(false);
 
             var resultingFolders = from i in folder
                 select new Folder() { Id = i.Id, Name = i.Name, IsInbox = i.IsInbox, FileCount = i.FileCount };
@@ -42,14 +42,14 @@ namespace Xero.Api.Core.Endpoints
         {
             if (response.StatusCode == HttpStatusCode.OK)
             {
-                var body = await response.Content.ReadAsStringAsync();
+                var body = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
 
                 var result = Client.JsonMapper.From<FoldersResponse[]>(body);
 
                 return result;
             }
 
-            await Client.HandleErrorsAsync(response);
+            await Client.HandleErrorsAsync(response).ConfigureAwait(false);
 
             return null;
         }

--- a/Xero.Api/Core/Endpoints/InvoicesEndpoint.cs
+++ b/Xero.Api/Core/Endpoints/InvoicesEndpoint.cs
@@ -65,19 +65,19 @@ namespace Xero.Api.Core.Endpoints
 
         public async Task<OnlineInvoice> RetrieveOnlineInvoiceUrlAsync(Guid invoiceId)
         {
-            return (await Client.GetAsync<OnlineInvoice, OnlineInvoicesResponse>(string.Format("/api.xro/2.0/Invoices/{0}/OnlineInvoice", invoiceId))).FirstOrDefault();
+            return (await Client.GetAsync<OnlineInvoice, OnlineInvoicesResponse>(string.Format("/api.xro/2.0/Invoices/{0}/OnlineInvoice", invoiceId)).ConfigureAwait(false)).FirstOrDefault();
         }
 
         public async Task EmailInvoiceAsync(Guid id)
         {
-            var response =  await Client.PostAsync($"/api.xro/2.0/invoices/{id}/emails", new byte[]{});
+            var response =  await Client.PostAsync($"/api.xro/2.0/invoices/{id}/emails", new byte[]{}).ConfigureAwait(false);
 
             if (response.StatusCode == HttpStatusCode.NoContent)
             {
                 return;
             }
 
-            await Client.HandleErrorsAsync(response);
+            await Client.HandleErrorsAsync(response).ConfigureAwait(false);
         }
 
         public override void ClearQueryString()

--- a/Xero.Api/Core/Endpoints/ItemsEndpoint.cs
+++ b/Xero.Api/Core/Endpoints/ItemsEndpoint.cs
@@ -26,22 +26,22 @@ namespace Xero.Api.Core.Endpoints
         {
             var endpoint = string.Format("/api.xro/2.0/Items/{0}", itemToDelete.Id);
 
-            var response = await Client.DeleteAsync(endpoint);
+            var response = await Client.DeleteAsync(endpoint).ConfigureAwait(false);
 
-            await HandleResponseAsync(response);
+            await HandleResponseAsync(response).ConfigureAwait(false);
         }
 
         private async Task<ItemsResponse> HandleResponseAsync(HttpResponseMessage response)
         {
             if (response.StatusCode == HttpStatusCode.OK)
             {
-                var body = await response.Content.ReadAsStringAsync();
+                var body = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
 
                 var result = Client.JsonMapper.From<ItemsResponse>(body);
                 return result;
             }
 
-            await Client.HandleErrorsAsync(response);
+            await Client.HandleErrorsAsync(response).ConfigureAwait(false);
 
             return null;
         }

--- a/Xero.Api/Core/Endpoints/LinkedTransactionsEndpoint.cs
+++ b/Xero.Api/Core/Endpoints/LinkedTransactionsEndpoint.cs
@@ -32,9 +32,9 @@ namespace Xero.Api.Core.Endpoints
         {
             var endpoint = string.Format("/api.xro/2.0/LinkedTransactions/{0}", linkedTransaction.Id);
 
-            var response = await Client.DeleteAsync(endpoint);
+            var response = await Client.DeleteAsync(endpoint).ConfigureAwait(false);
 
-            await HandleResponseAsync(response);
+            await HandleResponseAsync(response).ConfigureAwait(false);
         }
 
         public ILinkedTransactionsEndpoint Page(int page)
@@ -67,13 +67,13 @@ namespace Xero.Api.Core.Endpoints
         {
             if (response.StatusCode == HttpStatusCode.OK)
             {
-                var body = await response.Content.ReadAsStringAsync();
+                var body = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
 
                 var result = Client.JsonMapper.From<LinkedTransactionsResponse>(body);
                 return result;
             }
 
-            await Client.HandleErrorsAsync(response);
+            await Client.HandleErrorsAsync(response).ConfigureAwait(false);
 
             return null;
         }

--- a/Xero.Api/Core/Endpoints/OrganisationEndpoint.cs
+++ b/Xero.Api/Core/Endpoints/OrganisationEndpoint.cs
@@ -22,7 +22,7 @@ namespace Xero.Api.Core.Endpoints
 
         public async Task<OrganisationCisSetting> GetCisSettingsAsync(Guid id)
         {
-            var organisationCisSettings = await Client.GetAsync<OrganisationCisSetting, OrganisationCisSettingsResponse>($"/api.xro/2.0/organisations/{id}/cissettings");
+            var organisationCisSettings = await Client.GetAsync<OrganisationCisSetting, OrganisationCisSettingsResponse>($"/api.xro/2.0/organisations/{id}/cissettings").ConfigureAwait(false);
 
             return organisationCisSettings.FirstOrDefault();
         }

--- a/Xero.Api/Core/Endpoints/PdfEndpoint.cs
+++ b/Xero.Api/Core/Endpoints/PdfEndpoint.cs
@@ -18,16 +18,16 @@ namespace Xero.Api.Core.Endpoints
 
         public async Task<BinaryFile> GetAsync(PdfEndpointType type, Guid parent)
         {
-            var response = await Client.GetRawAsync(string.Format("/api.xro/2.0/{0}/{1}", type, parent.ToString("D")), "application/pdf");
+            var response = await Client.GetRawAsync(string.Format("/api.xro/2.0/{0}/{1}", type, parent.ToString("D")), "application/pdf").ConfigureAwait(false);
 
             if (response.StatusCode == HttpStatusCode.OK)
             {
-                var stream = await response.Content.ReadAsStreamAsync();
+                var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
 
                 return new BinaryFile(stream, parent.ToString("D") + ".pdf", response.Content.Headers.ContentType.ToString(), (int)stream.Length);
             }
 
-            await Client.HandleErrorsAsync(response);
+            await Client.HandleErrorsAsync(response).ConfigureAwait(false);
 
             return null;
         }

--- a/Xero.Api/Core/Endpoints/ReportsEndpoint.cs
+++ b/Xero.Api/Core/Endpoints/ReportsEndpoint.cs
@@ -42,17 +42,17 @@ namespace Xero.Api.Core.Endpoints
 
         public async Task<Report> GetPublishedReportAsync(string id)
         {
-            return await FindAsync(id);
+            return await FindAsync(id).ConfigureAwait(false);
         }
 
         public async Task<Report> GetPublishedReportAsync(Guid id)
         {
-            return await FindAsync(id);
+            return await FindAsync(id).ConfigureAwait(false);
         }
 
         public async Task<IEnumerable<string>> PublishedAsync()
         {
-            return (await FindAsync()).Select(r => r.ReportID);
+            return (await FindAsync().ConfigureAwait(false)).Select(r => r.ReportID);
         }
 
         public IEnumerable<string> Named()
@@ -68,7 +68,7 @@ namespace Xero.Api.Core.Endpoints
 
             var endpoint = AddParameters(parameters);
 
-            return await endpoint.FindAsync(NamedReportType.TenNinetyNine.ToString());
+            return await endpoint.FindAsync(NamedReportType.TenNinetyNine.ToString()).ConfigureAwait(false);
         }
 
         public async Task<Report> AgedPayablesAsync(Guid contact, DateTime? date = null, DateTime? from = null, DateTime? to = null)
@@ -77,7 +77,7 @@ namespace Xero.Api.Core.Endpoints
 
             var endpoint = AddParameters(parameters);
 
-            return await endpoint.FindAsync(NamedReportType.AgedPayablesByContact.ToString());
+            return await endpoint.FindAsync(NamedReportType.AgedPayablesByContact.ToString()).ConfigureAwait(false);
         }
 
         public async Task<Report> AgedReceivablesAsync(Guid contact, DateTime? date = null, DateTime? from = null, DateTime? to = null)
@@ -86,7 +86,7 @@ namespace Xero.Api.Core.Endpoints
 
             var endpoint = AddParameters(parameters);
 
-            return await endpoint.FindAsync(NamedReportType.AgedReceivablesByContact.ToString());
+            return await endpoint.FindAsync(NamedReportType.AgedReceivablesByContact.ToString()).ConfigureAwait(false);
         }
 
         public async Task<Report> BalanceSheetAsync(DateTime date, Guid? tracking1 = null, Guid? tracking2 = null,
@@ -104,7 +104,7 @@ namespace Xero.Api.Core.Endpoints
             
             var endpoint = AddParameters(parameters);
 
-            return await endpoint.FindAsync(NamedReportType.BalanceSheet.ToString());
+            return await endpoint.FindAsync(NamedReportType.BalanceSheet.ToString()).ConfigureAwait(false);
         }
 
         public async Task<Report> BankStatementAsync(Guid account, DateTime? from = null, DateTime? to = null)
@@ -117,7 +117,7 @@ namespace Xero.Api.Core.Endpoints
 
             var endpoint = AddParameters(parameters);
 
-            return await endpoint.FindAsync(NamedReportType.BankStatement.ToString());
+            return await endpoint.FindAsync(NamedReportType.BankStatement.ToString()).ConfigureAwait(false);
         }
 
         public async Task<Report> BankSummaryAsync(DateTime? from = null, DateTime? to = null)
@@ -129,7 +129,7 @@ namespace Xero.Api.Core.Endpoints
 
             var endpoint = AddParameters(parameters);
 
-            return await endpoint.FindAsync(NamedReportType.BankSummary.ToString());
+            return await endpoint.FindAsync(NamedReportType.BankSummary.ToString()).ConfigureAwait(false);
         }
 
         public async Task<Report> BudgetSummaryAsync(DateTime? date = null, int? periods = null, BudgetSummaryTimeframeType? timeFrame = null)
@@ -142,7 +142,7 @@ namespace Xero.Api.Core.Endpoints
 
             var endpoint = AddParameters(parameters);
 
-            return await endpoint.FindAsync(NamedReportType.BudgetSummary.ToString());
+            return await endpoint.FindAsync(NamedReportType.BudgetSummary.ToString()).ConfigureAwait(false);
         }
 
         public async Task<Report> ExecutiveSummaryAsync(DateTime? date = null)
@@ -153,7 +153,7 @@ namespace Xero.Api.Core.Endpoints
 
             var endpoint = AddParameters(parameters);
 
-            return await endpoint.FindAsync(NamedReportType.ExecutiveSummary.ToString());
+            return await endpoint.FindAsync(NamedReportType.ExecutiveSummary.ToString()).ConfigureAwait(false);
         }
 
         public async Task<Report> ProfitAndLossAsync(DateTime? date, DateTime? from = null, DateTime? to = null,
@@ -176,7 +176,7 @@ namespace Xero.Api.Core.Endpoints
 
             var endpoint = AddParameters(parameters);
 
-            return await endpoint.FindAsync(NamedReportType.ProfitAndLoss.ToString());
+            return await endpoint.FindAsync(NamedReportType.ProfitAndLoss.ToString()).ConfigureAwait(false);
         }
 
         public async Task<Report> TrailBalanceAsync(DateTime? date = null, bool? paymentsOnly = null)
@@ -188,7 +188,7 @@ namespace Xero.Api.Core.Endpoints
 
             var endpoint = AddParameters(parameters);
 
-            return await endpoint.FindAsync(NamedReportType.TrialBalance.ToString());
+            return await endpoint.FindAsync(NamedReportType.TrialBalance.ToString()).ConfigureAwait(false);
         }
 
         private NameValueCollection GetAgedParameters(Guid contact, DateTime? date, DateTime? from, DateTime? to)

--- a/Xero.Api/Core/Endpoints/SetupEndpoint.cs
+++ b/Xero.Api/Core/Endpoints/SetupEndpoint.cs
@@ -31,28 +31,28 @@ namespace Xero.Api.Core.Endpoints
 
         public async Task<ImportSummary> UpdateAsync(Setup setup)
         {
-            var response = await _client.PostAsync(_apiEndpointUrl, setup);
+            var response = await _client.PostAsync(_apiEndpointUrl, setup).ConfigureAwait(false);
 
-            return await HandleResponseAsync(response);
+            return await HandleResponseAsync(response).ConfigureAwait(false);
         }
 
         public async Task<ImportSummary> CreateAsync(Setup setup)
         {
-            var response = await _client.PutAsync(_apiEndpointUrl, setup);
+            var response = await _client.PutAsync(_apiEndpointUrl, setup).ConfigureAwait(false);
 
-            return await HandleResponseAsync(response);
+            return await HandleResponseAsync(response).ConfigureAwait(false);
         }
 
         private async Task<ImportSummary> HandleResponseAsync(HttpResponseMessage response)
         {
             if (response.StatusCode == HttpStatusCode.OK)
             {
-                var body = await response.Content.ReadAsStringAsync();
+                var body = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
 
-                return _client.JsonMapper.From<SetupResponse>(body).ImportSummary;                
+                return _client.JsonMapper.From<SetupResponse>(body).ImportSummary;
             }
 
-            await _client.HandleErrorsAsync(response);
+            await _client.HandleErrorsAsync(response).ConfigureAwait(false);
 
             return null;
         }

--- a/Xero.Api/Core/Endpoints/TrackingCategoriesEndpoint.cs
+++ b/Xero.Api/Core/Endpoints/TrackingCategoriesEndpoint.cs
@@ -34,25 +34,25 @@ namespace Xero.Api.Core.Endpoints
 
         public async Task<List<Option>> AddOptionAsync(TrackingCategory trackingCategory, Option option)
         {
-            return await AddOptionsAsync(trackingCategory, new List<Option> {option});
+            return await AddOptionsAsync(trackingCategory, new List<Option> {option}).ConfigureAwait(false);
         }
 
         public async Task DeleteAsync(TrackingCategory trackingCategory)
         {
             var endpoint = string.Format("/api.xro/2.0/trackingcategories/{0}/", trackingCategory.Id);
 
-            var response = await Client.DeleteAsync(endpoint);
+            var response = await Client.DeleteAsync(endpoint).ConfigureAwait(false);
 
-            await HandleOptionsResponseAsync(response);
+            await HandleOptionsResponseAsync(response).ConfigureAwait(false);
         }
 
         public async Task<List<Option>> AddOptionsAsync(TrackingCategory trackingCategory, List<Option> options)
         {
             var endpoint = string.Format("/api.xro/2.0/trackingcategories/{0}/options", trackingCategory.Id);
 
-            var response = await Client.PutAsync(endpoint, options);
+            var response = await Client.PutAsync(endpoint, options).ConfigureAwait(false);
 
-            var result = await HandleOptionsResponseAsync(response);
+            var result = await HandleOptionsResponseAsync(response).ConfigureAwait(false);
             
             return result.Values.ToList();
         }
@@ -61,9 +61,9 @@ namespace Xero.Api.Core.Endpoints
         {
             var endpoint = string.Format("/api.xro/2.0/trackingcategories/{0}/options/{1}", trackingCategory.Id, option.Id);
 
-            var response = await Client.PostAsync(endpoint, new List<Option> {option});
+            var response = await Client.PostAsync(endpoint, new List<Option> {option}).ConfigureAwait(false);
 
-            var result = await HandleOptionsResponseAsync(response);
+            var result = await HandleOptionsResponseAsync(response).ConfigureAwait(false);
 
             return result.Values.ToList();
         }
@@ -72,9 +72,9 @@ namespace Xero.Api.Core.Endpoints
         {
             var endpoint = string.Format("/api.xro/2.0/TrackingCategories/{0}/Options/{1}", trackingCategory.Id, option.Id);
 
-            var response = await Client.DeleteAsync(endpoint);
+            var response = await Client.DeleteAsync(endpoint).ConfigureAwait(false);
 
-            var track = await HandleOptionsResponseAsync(response);
+            var track = await HandleOptionsResponseAsync(response).ConfigureAwait(false);
 
             return track.Values.FirstOrDefault();
         }
@@ -83,13 +83,13 @@ namespace Xero.Api.Core.Endpoints
         {
             if (response.StatusCode == HttpStatusCode.OK)
             {
-                var body = await response.Content.ReadAsStringAsync();
+                var body = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
 
                 var result = Client.JsonMapper.From<OptionsResponse>(body);
                 return result;
             }
 
-            await Client.HandleErrorsAsync(response);
+            await Client.HandleErrorsAsync(response).ConfigureAwait(false);
 
             return null;
         }

--- a/Xero.Api/Core/XeroCoreApi.cs
+++ b/Xero.Api/Core/XeroCoreApi.cs
@@ -113,7 +113,7 @@ namespace Xero.Api.Core
 
         public async Task<Organisation> FindOrganisationAsync()
         {
-            return (await Organisations.FindAsync()).FirstOrDefault();
+            return (await Organisations.FindAsync().ConfigureAwait(false)).FirstOrDefault();
         }
 
         // Note: Due to the immutability of endpoints, If you want to use filtering etc you will need to make requests via the endpoints themselves, not using the sugar methods below
@@ -122,22 +122,22 @@ namespace Xero.Api.Core
 
         public async Task<IEnumerable<Account>> CreateAsync(IEnumerable<Account> items)
         {
-            return await Accounts.CreateAsync(items);
+            return await Accounts.CreateAsync(items).ConfigureAwait(false);
         }
 
         public async Task<IEnumerable<Account>> UpdateAsync(IEnumerable<Account> items)
         {
-            return await Accounts.UpdateAsync(items);
+            return await Accounts.UpdateAsync(items).ConfigureAwait(false);
         }
 
         public async Task<Account> CreateAsync(Account item)
         {
-            return await Accounts.CreateAsync(item);
+            return await Accounts.CreateAsync(item).ConfigureAwait(false);
         }
 
         public async Task<Account> UpdateAsync(Account item)
         {
-            return await Accounts.UpdateAsync(item);
+            return await Accounts.UpdateAsync(item).ConfigureAwait(false);
         }
 
         #endregion
@@ -146,22 +146,22 @@ namespace Xero.Api.Core
 
         public async Task<IEnumerable<BankTransaction>> CreateAsync(IEnumerable<BankTransaction> items)
         {
-            return await BankTransactions.CreateAsync(items);
+            return await BankTransactions.CreateAsync(items).ConfigureAwait(false);
         }
 
         public async Task<IEnumerable<BankTransaction>> UpdateAsync(IEnumerable<BankTransaction> items)
         {
-            return await BankTransactions.UpdateAsync(items);
+            return await BankTransactions.UpdateAsync(items).ConfigureAwait(false);
         }
 
         public async Task<BankTransaction> CreateAsync(BankTransaction item)
         {
-            return await BankTransactions.CreateAsync(item);
+            return await BankTransactions.CreateAsync(item).ConfigureAwait(false);
         }
 
         public async Task<BankTransaction> UpdateAsync(BankTransaction item)
         {
-            return await BankTransactions.UpdateAsync(item);
+            return await BankTransactions.UpdateAsync(item).ConfigureAwait(false);
         }
 
         #endregion
@@ -170,12 +170,12 @@ namespace Xero.Api.Core
 
         public async Task<IEnumerable<BankTransfer>> CreateAsync(IEnumerable<BankTransfer> items)
         {
-            return await BankTransfers.CreateAsync(items);
+            return await BankTransfers.CreateAsync(items).ConfigureAwait(false);
         }
 
         public async Task<BankTransfer> CreateAsync(BankTransfer item)
         {
-            return await BankTransfers.CreateAsync(item);
+            return await BankTransfers.CreateAsync(item).ConfigureAwait(false);
         }
 
         #endregion
@@ -184,22 +184,22 @@ namespace Xero.Api.Core
 
         public async Task<IEnumerable<Contact>> CreateAsync(IEnumerable<Contact> items)
         {
-            return await Contacts.CreateAsync(items);
+            return await Contacts.CreateAsync(items).ConfigureAwait(false);
         }
 
         public async Task<IEnumerable<Contact>> UpdateAsync(IEnumerable<Contact> items)
         {
-            return await Contacts.UpdateAsync(items);
+            return await Contacts.UpdateAsync(items).ConfigureAwait(false);
         }
 
         public async Task<Contact> CreateAsync(Contact item)
         {
-            return await Contacts.CreateAsync(item);
+            return await Contacts.CreateAsync(item).ConfigureAwait(false);
         }
 
         public async Task<Contact> UpdateAsync(Contact item)
         {
-            return await Contacts.UpdateAsync(item);
+            return await Contacts.UpdateAsync(item).ConfigureAwait(false);
         }
 
         #endregion
@@ -208,22 +208,22 @@ namespace Xero.Api.Core
 
         public async Task<IEnumerable<ContactGroup>> CreateAsync(IEnumerable<ContactGroup> items)
         {
-            return await ContactGroups.CreateAsync(items);
+            return await ContactGroups.CreateAsync(items).ConfigureAwait(false);
         }
 
         public async Task<IEnumerable<ContactGroup>> UpdateAsync(IEnumerable<ContactGroup> items)
         {
-            return await ContactGroups.UpdateAsync(items);
+            return await ContactGroups.UpdateAsync(items).ConfigureAwait(false);
         }
 
         public async Task<ContactGroup> CreateAsync(ContactGroup item)
         {
-            return await ContactGroups.CreateAsync(item);
+            return await ContactGroups.CreateAsync(item).ConfigureAwait(false);
         }
 
         public async Task<ContactGroup> UpdateAsync(ContactGroup item)
         {
-            return await ContactGroups.UpdateAsync(item);
+            return await ContactGroups.UpdateAsync(item).ConfigureAwait(false);
         }
 
         #endregion
@@ -232,22 +232,22 @@ namespace Xero.Api.Core
 
         public async Task<IEnumerable<CreditNote>> CreateAsync(IEnumerable<CreditNote> items)
         {
-            return await CreditNotes.CreateAsync(items);
+            return await CreditNotes.CreateAsync(items).ConfigureAwait(false);
         }
 
         public async Task<IEnumerable<CreditNote>> UpdateAsync(IEnumerable<CreditNote> items)
         {
-            return await CreditNotes.UpdateAsync(items);
+            return await CreditNotes.UpdateAsync(items).ConfigureAwait(false);
         }
 
         public async Task<CreditNote> CreateAsync(CreditNote item)
         {
-            return await CreditNotes.CreateAsync(item);
+            return await CreditNotes.CreateAsync(item).ConfigureAwait(false);
         }
 
         public async Task<CreditNote> UpdateAsync(CreditNote item)
         {
-            return await CreditNotes.UpdateAsync(item);
+            return await CreditNotes.UpdateAsync(item).ConfigureAwait(false);
         }
 
         #endregion
@@ -256,22 +256,22 @@ namespace Xero.Api.Core
 
         public async Task<IEnumerable<Employee>> CreateAsync(IEnumerable<Employee> items)
         {
-            return await Employees.CreateAsync(items);
+            return await Employees.CreateAsync(items).ConfigureAwait(false);
         }
 
         public async Task<IEnumerable<Employee>> UpdateAsync(IEnumerable<Employee> items)
         {
-            return await Employees.UpdateAsync(items);
+            return await Employees.UpdateAsync(items).ConfigureAwait(false);
         }
 
         public async Task<Employee> CreateAsync(Employee item)
         {
-            return await Employees.CreateAsync(item);
+            return await Employees.CreateAsync(item).ConfigureAwait(false);
         }
 
         public async Task<Employee> UpdateAsync(Employee item)
         {
-            return await Employees.UpdateAsync(item);
+            return await Employees.UpdateAsync(item).ConfigureAwait(false);
         }
 
         #endregion
@@ -280,22 +280,22 @@ namespace Xero.Api.Core
 
         public async Task<IEnumerable<ExpenseClaim>> CreateAsync(IEnumerable<ExpenseClaim> items)
         {
-            return await ExpenseClaims.CreateAsync(items);
+            return await ExpenseClaims.CreateAsync(items).ConfigureAwait(false);
         }
 
         public async Task<IEnumerable<ExpenseClaim>> UpdateAsync(IEnumerable<ExpenseClaim> items)
         {
-            return await ExpenseClaims.UpdateAsync(items);
+            return await ExpenseClaims.UpdateAsync(items).ConfigureAwait(false);
         }
 
         public async Task<ExpenseClaim> CreateAsync(ExpenseClaim item)
         {
-            return await ExpenseClaims.CreateAsync(item);
+            return await ExpenseClaims.CreateAsync(item).ConfigureAwait(false);
         }
 
         public async Task<ExpenseClaim> UpdateAsync(ExpenseClaim item)
         {
-            return await ExpenseClaims.UpdateAsync(item);
+            return await ExpenseClaims.UpdateAsync(item).ConfigureAwait(false);
         }
 
         #endregion
@@ -304,22 +304,22 @@ namespace Xero.Api.Core
 
         public async Task<IEnumerable<Invoice>> CreateAsync(IEnumerable<Invoice> items)
         {
-            return await Invoices.CreateAsync(items);
+            return await Invoices.CreateAsync(items).ConfigureAwait(false);
         }
 
         public async Task<IEnumerable<Invoice>> UpdateAsync(IEnumerable<Invoice> items)
         {
-            return await Invoices.UpdateAsync(items);
+            return await Invoices.UpdateAsync(items).ConfigureAwait(false);
         }
 
         public async Task<Invoice> CreateAsync(Invoice item)
         {
-            return await Invoices.CreateAsync(item);
+            return await Invoices.CreateAsync(item).ConfigureAwait(false);
         }
 
         public async Task<Invoice> UpdateAsync(Invoice item)
         {
-            return await Invoices.UpdateAsync(item);
+            return await Invoices.UpdateAsync(item).ConfigureAwait(false);
         }
 
         #endregion
@@ -328,22 +328,22 @@ namespace Xero.Api.Core
 
         public async Task<IEnumerable<Item>> CreateAsync(IEnumerable<Item> items)
         {
-            return await Items.CreateAsync(items);
+            return await Items.CreateAsync(items).ConfigureAwait(false);
         }
 
         public async Task<IEnumerable<Item>> UpdateAsync(IEnumerable<Item> items)
         {
-            return await Items.UpdateAsync(items);
+            return await Items.UpdateAsync(items).ConfigureAwait(false);
         }
 
         public async Task<Item> CreateAsync(Item item)
         {
-            return await Items.CreateAsync(item);
+            return await Items.CreateAsync(item).ConfigureAwait(false);
         }
 
         public async Task<Item> UpdateAsync(Item item)
         {
-            return await Items.UpdateAsync(item);
+            return await Items.UpdateAsync(item).ConfigureAwait(false);
         }
 
         #endregion
@@ -352,22 +352,22 @@ namespace Xero.Api.Core
 
         public async Task<IEnumerable<LinkedTransaction>> CreateAsync(IEnumerable<LinkedTransaction> items)
         {
-            return await LinkedTransactions.CreateAsync(items);
+            return await LinkedTransactions.CreateAsync(items).ConfigureAwait(false);
         }
 
         public async Task<IEnumerable<LinkedTransaction>> UpdateAsync(IEnumerable<LinkedTransaction> items)
         {
-            return await LinkedTransactions.UpdateAsync(items);
+            return await LinkedTransactions.UpdateAsync(items).ConfigureAwait(false);
         }
 
         public async Task<LinkedTransaction> CreateAsync(LinkedTransaction item)
         {
-            return await LinkedTransactions.CreateAsync(item);
+            return await LinkedTransactions.CreateAsync(item).ConfigureAwait(false);
         }
 
         public async Task<LinkedTransaction> UpdateAsync(LinkedTransaction item)
         {
-            return await LinkedTransactions.UpdateAsync(item);
+            return await LinkedTransactions.UpdateAsync(item).ConfigureAwait(false);
         }
 
         #endregion
@@ -376,22 +376,22 @@ namespace Xero.Api.Core
 
         public async Task<IEnumerable<ManualJournal>> CreateAsync(IEnumerable<ManualJournal> items)
         {
-            return await ManualJournals.CreateAsync(items);
+            return await ManualJournals.CreateAsync(items).ConfigureAwait(false);
         }
 
         public async Task<IEnumerable<ManualJournal>> UpdateAsync(IEnumerable<ManualJournal> items)
         {
-            return await ManualJournals.UpdateAsync(items);
+            return await ManualJournals.UpdateAsync(items).ConfigureAwait(false);
         }
 
         public async Task<ManualJournal> CreateAsync(ManualJournal item)
         {
-            return await ManualJournals.CreateAsync(item);
+            return await ManualJournals.CreateAsync(item).ConfigureAwait(false);
         }
 
         public async Task<ManualJournal> UpdateAsync(ManualJournal item)
         {
-            return await ManualJournals.UpdateAsync(item);
+            return await ManualJournals.UpdateAsync(item).ConfigureAwait(false);
         }
 
         #endregion
@@ -400,22 +400,22 @@ namespace Xero.Api.Core
 
         public async Task<IEnumerable<Payment>> CreateAsync(IEnumerable<Payment> items)
         {
-            return await Payments.CreateAsync(items);
+            return await Payments.CreateAsync(items).ConfigureAwait(false);
         }
 
         public async Task<IEnumerable<Payment>> UpdateAsync(IEnumerable<Payment> items)
         {
-            return await Payments.UpdateAsync(items);
+            return await Payments.UpdateAsync(items).ConfigureAwait(false);
         }
 
         public async Task<Payment> CreateAsync(Payment item)
         {
-            return await Payments.CreateAsync(item);
+            return await Payments.CreateAsync(item).ConfigureAwait(false);
         }
 
         public async Task<Payment> UpdateAsync(Payment item)
         {
-            return await Payments.UpdateAsync(item);
+            return await Payments.UpdateAsync(item).ConfigureAwait(false);
         }
 
         #endregion
@@ -424,22 +424,22 @@ namespace Xero.Api.Core
 
         public async Task<IEnumerable<PurchaseOrder>> CreateAsync(IEnumerable<PurchaseOrder> items)
         {
-            return await PurchaseOrders.CreateAsync(items);
+            return await PurchaseOrders.CreateAsync(items).ConfigureAwait(false);
         }
 
         public async Task<IEnumerable<PurchaseOrder>> UpdateAsync(IEnumerable<PurchaseOrder> items)
         {
-            return await PurchaseOrders.UpdateAsync(items);
+            return await PurchaseOrders.UpdateAsync(items).ConfigureAwait(false);
         }
 
         public async Task<PurchaseOrder> CreateAsync(PurchaseOrder item)
         {
-            return await PurchaseOrders.CreateAsync(item);
+            return await PurchaseOrders.CreateAsync(item).ConfigureAwait(false);
         }
 
         public async Task<PurchaseOrder> UpdateAsync(PurchaseOrder item)
         {
-            return await PurchaseOrders.UpdateAsync(item);
+            return await PurchaseOrders.UpdateAsync(item).ConfigureAwait(false);
         }
 
         #endregion
@@ -448,22 +448,22 @@ namespace Xero.Api.Core
 
         public async Task<IEnumerable<Receipt>> CreateAsync(IEnumerable<Receipt> items)
         {
-            return await Receipts.CreateAsync(items);
+            return await Receipts.CreateAsync(items).ConfigureAwait(false);
         }
 
         public async Task<IEnumerable<Receipt>> UpdateAsync(IEnumerable<Receipt> items)
         {
-            return await Receipts.UpdateAsync(items);
+            return await Receipts.UpdateAsync(items).ConfigureAwait(false);
         }
 
         public async Task<Receipt> CreateAsync(Receipt item)
         {
-            return await Receipts.CreateAsync(item);
+            return await Receipts.CreateAsync(item).ConfigureAwait(false);
         }
 
         public async Task<Receipt> UpdateAsync(Receipt item)
         {
-            return await Receipts.UpdateAsync(item);
+            return await Receipts.UpdateAsync(item).ConfigureAwait(false);
         }
 
         #endregion
@@ -472,12 +472,12 @@ namespace Xero.Api.Core
 
         public async Task<ImportSummary> CreateAsync(Setup item)
         {
-            return await Setup.CreateAsync(item);
+            return await Setup.CreateAsync(item).ConfigureAwait(false);
         }
 
         public async Task<ImportSummary> UpdateAsync(Setup item)
         {
-            return await Setup.UpdateAsync(item);
+            return await Setup.UpdateAsync(item).ConfigureAwait(false);
         }
 
         #endregion
@@ -486,22 +486,22 @@ namespace Xero.Api.Core
 
         public async Task<IEnumerable<TaxRate>> CreateAsync(IEnumerable<TaxRate> items)
         {
-            return await TaxRates.CreateAsync(items);
+            return await TaxRates.CreateAsync(items).ConfigureAwait(false);
         }
 
         public async Task<IEnumerable<TaxRate>> UpdateAsync(IEnumerable<TaxRate> items)
         {
-            return await TaxRates.UpdateAsync(items);
+            return await TaxRates.UpdateAsync(items).ConfigureAwait(false);
         }
 
         public async Task<TaxRate> CreateAsync(TaxRate item)
         {
-            return await TaxRates.CreateAsync(item);
+            return await TaxRates.CreateAsync(item).ConfigureAwait(false);
         }
 
         public async Task<TaxRate> UpdateAsync(TaxRate item)
         {
-            return await TaxRates.UpdateAsync(item);
+            return await TaxRates.UpdateAsync(item).ConfigureAwait(false);
         }
 
         #endregion
@@ -510,22 +510,22 @@ namespace Xero.Api.Core
 
         public async Task<IEnumerable<TrackingCategory>> CreateAsync(IEnumerable<TrackingCategory> items)
         {
-            return await TrackingCategories.CreateAsync(items);
+            return await TrackingCategories.CreateAsync(items).ConfigureAwait(false);
         }
 
         public async Task<IEnumerable<TrackingCategory>> UpdateAsync(IEnumerable<TrackingCategory> items)
         {
-            return await TrackingCategories.UpdateAsync(items);
+            return await TrackingCategories.UpdateAsync(items).ConfigureAwait(false);
         }
 
         public async Task<TrackingCategory> CreateAsync(TrackingCategory item)
         {
-            return await TrackingCategories.CreateAsync(item);
+            return await TrackingCategories.CreateAsync(item).ConfigureAwait(false);
         }
 
         public async Task<TrackingCategory> UpdateAsync(TrackingCategory item)
         {
-            return await TrackingCategories.UpdateAsync(item);
+            return await TrackingCategories.UpdateAsync(item).ConfigureAwait(false);
         }
 
         #endregion

--- a/Xero.Api/Infrastructure/Http/XeroHttpClient.cs
+++ b/Xero.Api/Infrastructure/Http/XeroHttpClient.cs
@@ -63,9 +63,9 @@ namespace Xero.Api.Infrastructure.Http
 
             var request = CreateRequest(endPoint, HttpMethod.Get, modifiedSince, query: queryString);
 
-            var response = await SendRequestAsync(request);
+            var response = await SendRequestAsync(request).ConfigureAwait(false);
 
-            return await ReadAsync<TResult, TResponse>(response);
+            return await ReadAsync<TResult, TResponse>(response).ConfigureAwait(false);
         }
 
         internal async Task<IEnumerable<TResult>> PostAsync<TResult, TResponse>(string endpoint, byte[] data, string mimeType, NameValueCollection parameters = null)
@@ -78,9 +78,9 @@ namespace Xero.Api.Infrastructure.Http
 
             var request = CreateRequest(endpoint, HttpMethod.Post, content: content, query: queryString);
 
-            var response = await SendRequestAsync(request);
+            var response = await SendRequestAsync(request).ConfigureAwait(false);
 
-            return await ReadAsync<TResult, TResponse>(response);
+            return await ReadAsync<TResult, TResponse>(response).ConfigureAwait(false);
         }
 
         public async Task<IEnumerable<TResult>> PostAsync<TResult, TResponse>(string endpoint, object data, NameValueCollection parameters = null)
@@ -92,9 +92,9 @@ namespace Xero.Api.Infrastructure.Http
 
             var request = CreateRequest(endpoint, HttpMethod.Post, content: content, query: queryString);
 
-            var response = await SendRequestAsync(request);
+            var response = await SendRequestAsync(request).ConfigureAwait(false);
 
-            return await ReadAsync<TResult, TResponse>(response);
+            return await ReadAsync<TResult, TResponse>(response).ConfigureAwait(false);
         }
 
         public async Task<IEnumerable<TResult>> PutAsync<TResult, TResponse>(string endpoint, object data, NameValueCollection parameters = null)
@@ -106,9 +106,9 @@ namespace Xero.Api.Infrastructure.Http
 
             var request = CreateRequest(endpoint, HttpMethod.Put, content: content, query: queryString);
 
-            var response = await SendRequestAsync(request);
+            var response = await SendRequestAsync(request).ConfigureAwait(false);
 
-            return await ReadAsync<TResult, TResponse>(response);
+            return await ReadAsync<TResult, TResponse>(response).ConfigureAwait(false);
         }
 
         public async Task<IEnumerable<TResult>> DeleteAsync<TResult, TResponse>(string endpoint)
@@ -116,28 +116,28 @@ namespace Xero.Api.Infrastructure.Http
         {
             var request = CreateRequest(endpoint, HttpMethod.Delete);
 
-            var response = await SendRequestAsync(request);
+            var response = await SendRequestAsync(request).ConfigureAwait(false);
 
-            return await ReadAsync<TResult, TResponse>(response);
+            return await ReadAsync<TResult, TResponse>(response).ConfigureAwait(false);
         }
 
         internal async Task<HttpResponseMessage> GetAsync(string endpoint)
         {
-            return await GetAsync(endpoint, null);
+            return await GetAsync(endpoint, null).ConfigureAwait(false);
         }
 
         internal async Task<HttpResponseMessage> GetAsync(string endpoint, string query)
         {
             var request = CreateRequest(endpoint, HttpMethod.Get, query: query);
 
-            return await SendRequestAsync(request);
+            return await SendRequestAsync(request).ConfigureAwait(false);
         }
 
         internal async Task<HttpResponseMessage> GetRawAsync(string endpoint, string mimetype)
         {
             var request = CreateRequest(endpoint, HttpMethod.Get, accept: mimetype);
 
-            return await SendRequestAsync(request);
+            return await SendRequestAsync(request).ConfigureAwait(false);
         }
 
         internal async Task<HttpResponseMessage> PutAsync(string endpoint, object data, bool json = false, NameValueCollection parameters = null)
@@ -150,7 +150,7 @@ namespace Xero.Api.Infrastructure.Http
 
             var request = CreateRequest(endpoint, HttpMethod.Put, content: content, query: queryString);
 
-            return await SendRequestAsync(request);
+            return await SendRequestAsync(request).ConfigureAwait(false);
         }
 
         internal async Task<HttpResponseMessage> PostAsync(string endpoint, object data, bool json = false, NameValueCollection parameters = null)
@@ -163,14 +163,14 @@ namespace Xero.Api.Infrastructure.Http
 
             var request = CreateRequest(endpoint, HttpMethod.Post, content: content, query: queryString);
 
-            return await SendRequestAsync(request);
+            return await SendRequestAsync(request).ConfigureAwait(false);
         }
 
         internal async Task<HttpResponseMessage> DeleteAsync(string endpoint)
         {
             var request = CreateRequest(endpoint, HttpMethod.Delete);
 
-            return await SendRequestAsync(request);
+            return await SendRequestAsync(request).ConfigureAwait(false);
         }
 
         public async Task<HttpResponseMessage> PostMultipartFormAsync(string endpoint, string contentType, string name, string filename, byte[] payload)
@@ -179,7 +179,7 @@ namespace Xero.Api.Infrastructure.Http
 
             request.Content = CreateMultipartData(payload, name, filename);
 
-            return await SendRequestAsync(request);
+            return await SendRequestAsync(request).ConfigureAwait(false);
         }
 
         private HttpRequestMessage CreateRequest(string endPoint, HttpMethod method, DateTime? modifiedSince = null, string accept = "application/json", HttpContent content = null, string query = null)
@@ -222,7 +222,7 @@ namespace Xero.Api.Infrastructure.Http
             if (_rateLimiter != null)
                 _rateLimiter.WaitUntilLimit();
 
-            return await HttpClient.SendAsync(request);
+            return await HttpClient.SendAsync(request).ConfigureAwait(false);
         }
 
         private string CreateQueryString(string where, string order, NameValueCollection paramters, bool encoded)
@@ -246,19 +246,19 @@ namespace Xero.Api.Infrastructure.Http
             // this is the 'happy path'
             if (response.StatusCode == HttpStatusCode.OK)
             {
-                var content = await response.Content.ReadAsStringAsync();
+                var content = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
 
                 return JsonMapper.From<TResponse>(content).Values;
             }
 
-            await HandleErrorsAsync(response);
+            await HandleErrorsAsync(response).ConfigureAwait(false);
 
             return null;
         }
 
         internal async Task HandleErrorsAsync(HttpResponseMessage response)
         {
-            var body = await response.Content.ReadAsStringAsync();
+            var body = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
 
             if (response.StatusCode == HttpStatusCode.BadRequest)
             {

--- a/Xero.Api/Infrastructure/OAuth/OAuthTokens.cs
+++ b/Xero.Api/Infrastructure/OAuth/OAuthTokens.cs
@@ -31,17 +31,17 @@ namespace Xero.Api.Infrastructure.OAuth
 
         public async Task<IToken> GetRequestTokenAsync(IConsumer consumer, string header)
         {
-            return await GetTokenAsync(new Token { ConsumerKey = consumer.ConsumerKey, ConsumerSecret = consumer.ConsumerSecret }, RequestTokenEndpoint, header);
+            return await GetTokenAsync(new Token { ConsumerKey = consumer.ConsumerKey, ConsumerSecret = consumer.ConsumerSecret }, RequestTokenEndpoint, header).ConfigureAwait(false);
         }
 
         public async Task<IToken> GetAccessTokenAsync(IToken token, string header)
         {
-            return await GetTokenAsync(token, AccessTokenEndpoint, header);
+            return await GetTokenAsync(token, AccessTokenEndpoint, header).ConfigureAwait(false);
         }
 
         public async Task<IToken> RenewAccessTokenAsync(IToken token, string header)
         {
-            return await GetTokenAsync(token, AccessTokenEndpoint, header);
+            return await GetTokenAsync(token, AccessTokenEndpoint, header).ConfigureAwait(false);
         }
 
         public async Task<IToken> GetTokenAsync(IToken consumer, string endpoint, string header)
@@ -52,8 +52,8 @@ namespace Xero.Api.Infrastructure.OAuth
 
             request.Headers.Add("Authorization", header);
 
-            var response = await _httpClient.SendAsync(request);
-            var body = await response.Content.ReadAsStringAsync();
+            var response = await _httpClient.SendAsync(request).ConfigureAwait(false);
+            var body = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
 
 
             if (response.StatusCode != HttpStatusCode.OK)

--- a/Xero.Api/Payroll/AmericanPayroll.cs
+++ b/Xero.Api/Payroll/AmericanPayroll.cs
@@ -35,129 +35,129 @@ namespace Xero.Api.Payroll
             Employees = new EmployeesEndpoint(Client);
             PayRuns = new PayRunsEndpoint(Client);
             Settings = new SettingsEndpoint(Client);
-            Timesheets = new TimesheetsEndpoint(Client);            
+            Timesheets = new TimesheetsEndpoint(Client);
         }
 
         // Note: Due to the immutability of endpoints, If you want to use filtering etc you will need to make requests via the endpoints themselves, not using the sugar methods below
 
         public async Task<IEnumerable<PaySchedule>> CreateAsync(IEnumerable<PaySchedule> items)
         {
-            return await PaySchedules.CreateAsync(items);
+            return await PaySchedules.CreateAsync(items).ConfigureAwait(false);
         }
 
         public async Task<IEnumerable<WorkLocation>> CreateAsync(IEnumerable<WorkLocation> items)
         {
-            return await WorkLocations.CreateAsync(items);
+            return await WorkLocations.CreateAsync(items).ConfigureAwait(false);
         }
 
         public async Task<IEnumerable<PayStub>> CreateAsync(IEnumerable<PayStub> items)
         {
-            return await PayStubs.CreateAsync(items);
+            return await PayStubs.CreateAsync(items).ConfigureAwait(false);
         }
 
         public async Task<IEnumerable<Employee>> CreateAsync(IEnumerable<Employee> items)
         {
-            return await Employees.CreateAsync(items);
+            return await Employees.CreateAsync(items).ConfigureAwait(false);
         }
 
         public async Task<IEnumerable<PayRun>> CreateAsync(IEnumerable<PayRun> items)
         {
-            return await PayRuns.CreateAsync(items);
+            return await PayRuns.CreateAsync(items).ConfigureAwait(false);
         }
 
         public async Task<IEnumerable<Timesheet>> CreateAsync(IEnumerable<Timesheet> items)
         {
-            return await Timesheets.CreateAsync(items);
+            return await Timesheets.CreateAsync(items).ConfigureAwait(false);
         }
 
         public async Task<PaySchedule> CreateAsync(PaySchedule item)
         {
-            return await PaySchedules.CreateAsync(item);
+            return await PaySchedules.CreateAsync(item).ConfigureAwait(false);
         }
 
         public async Task<WorkLocation> CreateAsync(WorkLocation item)
         {
-            return await WorkLocations.CreateAsync(item);
+            return await WorkLocations.CreateAsync(item).ConfigureAwait(false);
         }
 
         public async Task<PayStub> CreateAsync(PayStub item)
         {
-            return await PayStubs.CreateAsync(item);
+            return await PayStubs.CreateAsync(item).ConfigureAwait(false);
         }
 
         public async Task<Employee> CreateAsync(Employee item)
         {
-            return await Employees.CreateAsync(item);
+            return await Employees.CreateAsync(item).ConfigureAwait(false);
         }
 
         public async Task<PayRun> CreateAsync(PayRun item)
         {
-            return await PayRuns.CreateAsync(item);
+            return await PayRuns.CreateAsync(item).ConfigureAwait(false);
         }
 
         public async Task<Timesheet> CreateAsync(Timesheet item)
         {
-            return await Timesheets.CreateAsync(item);
+            return await Timesheets.CreateAsync(item).ConfigureAwait(false);
         }
 
         public async Task<IEnumerable<PaySchedule>> UpdateAsync(IEnumerable<PaySchedule> items)
         {
-            return await PaySchedules.UpdateAsync(items);
+            return await PaySchedules.UpdateAsync(items).ConfigureAwait(false);
         }
 
         public async Task<IEnumerable<WorkLocation>> UpdateAsync(IEnumerable<WorkLocation> items)
         {
-            return await WorkLocations.UpdateAsync(items);
+            return await WorkLocations.UpdateAsync(items).ConfigureAwait(false);
         }
 
         public async Task<IEnumerable<PayStub>> UpdateAsync(IEnumerable<PayStub> items)
         {
-            return await PayStubs.UpdateAsync(items);
+            return await PayStubs.UpdateAsync(items).ConfigureAwait(false);
         }
 
         public async Task<IEnumerable<Employee>> UpdateAsync(IEnumerable<Employee> items)
         {
-            return await Employees.UpdateAsync(items);
+            return await Employees.UpdateAsync(items).ConfigureAwait(false);
         }
 
         public async Task<IEnumerable<PayRun>> UpdateAsync(IEnumerable<PayRun> items)
         {
-            return await PayRuns.UpdateAsync(items);
+            return await PayRuns.UpdateAsync(items).ConfigureAwait(false);
         }
 
         public async Task<IEnumerable<Timesheet>> UpdateAsync(IEnumerable<Timesheet> items)
         {
-            return await Timesheets.UpdateAsync(items);
+            return await Timesheets.UpdateAsync(items).ConfigureAwait(false);
         }
 
         public async Task<PaySchedule> UpdateAsync(PaySchedule item)
         {
-            return await PaySchedules.UpdateAsync(item);
+            return await PaySchedules.UpdateAsync(item).ConfigureAwait(false);
         }
 
         public async Task<WorkLocation> UpdateAsync(WorkLocation item)
         {
-            return await WorkLocations.UpdateAsync(item);
+            return await WorkLocations.UpdateAsync(item).ConfigureAwait(false);
         }
 
         public async Task<PayStub> UpdateAsync(PayStub item)
         {
-            return await PayStubs.UpdateAsync(item);
+            return await PayStubs.UpdateAsync(item).ConfigureAwait(false);
         }
 
         public async Task<Employee> UpdateAsync(Employee item)
         {
-            return await Employees.UpdateAsync(item);
+            return await Employees.UpdateAsync(item).ConfigureAwait(false);
         }
 
         public async Task<PayRun> UpdateAsync(PayRun item)
         {
-            return await PayRuns.UpdateAsync(item);
+            return await PayRuns.UpdateAsync(item).ConfigureAwait(false);
         }
 
         public async Task<Timesheet> UpdateAsync(Timesheet item)
         {
-            return await Timesheets.UpdateAsync(item);
+            return await Timesheets.UpdateAsync(item).ConfigureAwait(false);
         }
     }
 }

--- a/Xero.Api/Payroll/AustralianPayroll.cs
+++ b/Xero.Api/Payroll/AustralianPayroll.cs
@@ -49,152 +49,152 @@ namespace Xero.Api.Payroll
 
         public async Task<IEnumerable<LeaveApplication>> CreateAsync(IEnumerable<LeaveApplication> items)
         {
-            return await LeaveApplications.CreateAsync(items);
+            return await LeaveApplications.CreateAsync(items).ConfigureAwait(false);
         }
 
         public async Task<IEnumerable<Payslip>> CreateAsync(IEnumerable<Payslip> items)
         {
-            return await Payslips.CreateAsync(items);
+            return await Payslips.CreateAsync(items).ConfigureAwait(false);
         }
 
         public async Task<IEnumerable<SuperFund>> CreateAsync(IEnumerable<SuperFund> items)
         {
-            return await SuperFunds.CreateAsync(items);
+            return await SuperFunds.CreateAsync(items).ConfigureAwait(false);
         }
 
         public async Task<IEnumerable<Employee>> CreateAsync(IEnumerable<Employee> items)
         {
-            return await Employees.CreateAsync(items);
+            return await Employees.CreateAsync(items).ConfigureAwait(false);
         }
 
         public async Task<IEnumerable<PayRun>> CreateAsync(IEnumerable<PayRun> items)
         {
-            return await PayRuns.CreateAsync(items);
+            return await PayRuns.CreateAsync(items).ConfigureAwait(false);
         }
 
         public async Task<IEnumerable<Timesheet>> CreateAsync(IEnumerable<Timesheet> items)
         {
-            return await Timesheets.CreateAsync(items);
+            return await Timesheets.CreateAsync(items).ConfigureAwait(false);
         }
 
         public async Task<IEnumerable<PayrollCalendar>> CreateAsync(IEnumerable<PayrollCalendar> items)
         {
-            return await PayrollCalendars.CreateAsync(items);
+            return await PayrollCalendars.CreateAsync(items).ConfigureAwait(false);
         }
 
         public async Task<LeaveApplication> CreateAsync(LeaveApplication item)
         {
-            return await LeaveApplications.CreateAsync(item);
+            return await LeaveApplications.CreateAsync(item).ConfigureAwait(false);
         }
 
         public async Task<Payslip> CreateAsync(Payslip item)
         {
-            return await Payslips.CreateAsync(item);
+            return await Payslips.CreateAsync(item).ConfigureAwait(false);
         }
 
         public async Task<SuperFund> CreateAsync(SuperFund item)
         {
-            return await SuperFunds.CreateAsync(item);
+            return await SuperFunds.CreateAsync(item).ConfigureAwait(false);
         }
 
         public async Task<Employee> CreateAsync(Employee item)
         {
-            return await Employees.CreateAsync(item);
+            return await Employees.CreateAsync(item).ConfigureAwait(false);
         }
 
         public async Task<PayRun> CreateAsync(PayRun item)
         {
-            return await PayRuns.CreateAsync(item);
+            return await PayRuns.CreateAsync(item).ConfigureAwait(false);
         }
 
         public async Task<Timesheet> CreateAsync(Timesheet item)
         {
-            return await Timesheets.CreateAsync(item);
+            return await Timesheets.CreateAsync(item).ConfigureAwait(false);
         }
 
         public async Task<PayItems> CreateAsync(PayItems item)
         {
-            return await PayItems.CreateAsync(item);
+            return await PayItems.CreateAsync(item).ConfigureAwait(false);
         }
 
         public async Task<PayrollCalendar> CreateAsync(PayrollCalendar item)
         {
-            return await PayrollCalendars.CreateAsync(item);
+            return await PayrollCalendars.CreateAsync(item).ConfigureAwait(false);
         }
 
         public async Task<IEnumerable<LeaveApplication>> UpdateAsync(IEnumerable<LeaveApplication> items)
         {
-            return await LeaveApplications.UpdateAsync(items);
+            return await LeaveApplications.UpdateAsync(items).ConfigureAwait(false);
         }
 
         public async Task<IEnumerable<Payslip>> UpdateAsync(IEnumerable<Payslip> items)
         {
-            return await Payslips.UpdateAsync(items);
+            return await Payslips.UpdateAsync(items).ConfigureAwait(false);
         }
 
         public async Task<IEnumerable<SuperFund>> UpdateAsync(IEnumerable<SuperFund> items)
         {
-            return await SuperFunds.UpdateAsync(items);
+            return await SuperFunds.UpdateAsync(items).ConfigureAwait(false);
         }
 
         public async Task<IEnumerable<Employee>> UpdateAsync(IEnumerable<Employee> items)
         {
-            return await Employees.UpdateAsync(items);
+            return await Employees.UpdateAsync(items).ConfigureAwait(false);
         }
 
         public async Task<IEnumerable<PayRun>> UpdateAsync(IEnumerable<PayRun> items)
         {
-            return await PayRuns.UpdateAsync(items);
+            return await PayRuns.UpdateAsync(items).ConfigureAwait(false);
         }
 
         public async Task<IEnumerable<Timesheet>> UpdateAsync(IEnumerable<Timesheet> items)
         {
-            return await Timesheets.UpdateAsync(items);
+            return await Timesheets.UpdateAsync(items).ConfigureAwait(false);
         }
 
         public async Task<IEnumerable<PayrollCalendar>> UpdateAsync(IEnumerable<PayrollCalendar> items)
         {
-            return await PayrollCalendars.UpdateAsync(items);
+            return await PayrollCalendars.UpdateAsync(items).ConfigureAwait(false);
         }
 
         public async Task<LeaveApplication> UpdateAsync(LeaveApplication item)
         {
-            return await LeaveApplications.UpdateAsync(item);
+            return await LeaveApplications.UpdateAsync(item).ConfigureAwait(false);
         }
 
         public async Task<Payslip> UpdateAsync(Payslip item)
         {
-            return await Payslips.UpdateAsync(item);
+            return await Payslips.UpdateAsync(item).ConfigureAwait(false);
         }
 
         public async Task<SuperFund> UpdateAsync(SuperFund item)
         {
-            return await SuperFunds.UpdateAsync(item);
+            return await SuperFunds.UpdateAsync(item).ConfigureAwait(false);
         }
 
         public async Task<Employee> UpdateAsync(Employee item)
         {
-            return await Employees.UpdateAsync(item);
+            return await Employees.UpdateAsync(item).ConfigureAwait(false);
         }
 
         public async Task<PayRun> UpdateAsync(PayRun item)
         {
-            return await PayRuns.UpdateAsync(item);
+            return await PayRuns.UpdateAsync(item).ConfigureAwait(false);
         }
 
         public async Task<Timesheet> UpdateAsync(Timesheet item)
         {
-            return await Timesheets.UpdateAsync(item);
+            return await Timesheets.UpdateAsync(item).ConfigureAwait(false);
         }
 
         public async Task<PayItems> UpdateAsync(PayItems item)
         {
-            return await PayItems.UpdateAsync(item);
+            return await PayItems.UpdateAsync(item).ConfigureAwait(false);
         }
 
         public async Task<PayrollCalendar> UpdateAsync(PayrollCalendar item)
         {
-            return await PayrollCalendars.UpdateAsync(item);
+            return await PayrollCalendars.UpdateAsync(item).ConfigureAwait(false);
         }
     }
 }

--- a/Xero.Api/Payroll/Common/PayrollEndpoint.cs
+++ b/Xero.Api/Payroll/Common/PayrollEndpoint.cs
@@ -23,27 +23,27 @@ namespace Xero.Api.Payroll.Common
             var request = new TRequest();
             request.AddRange(items);
 
-            return await PostAsync(request);
+            return await PostAsync(request).ConfigureAwait(false);
         }
 
         public async Task<TResult> CreateAsync(TResult item)
         {
-            return (await CreateAsync(new [] { item })).First();
+            return (await CreateAsync(new [] { item }).ConfigureAwait(false)).First();
         }
 
         public async Task<IEnumerable<TResult>> UpdateAsync(IEnumerable<TResult> items)
         {
-            return await CreateAsync(items);
+            return await CreateAsync(items).ConfigureAwait(false);
         }
 
         public async Task<TResult> UpdateAsync(TResult item)
         {
-            return (await UpdateAsync(new[] { item })).First();
+            return (await UpdateAsync(new[] { item }).ConfigureAwait(false)).First();
         }
 
         protected async Task<IEnumerable<TResult>> PostAsync(TRequest data)
         {
-            return await Client.PostAsync<TResult, TResponse>(ApiEndpointUrl, data);
+            return await Client.PostAsync<TResult, TResponse>(ApiEndpointUrl, data).ConfigureAwait(false);
         }
 
         public T Page(int page)

--- a/Xero.Api/Xero.Api.csproj
+++ b/Xero.Api/Xero.Api.csproj
@@ -13,6 +13,7 @@
     <PackageIconUrl>https://secure.gravatar.com/avatar/7fff030fb8040a5157c3fd463858167f.png?s=128</PackageIconUrl>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="1.0.1" PrivateAssets="All" />
     <PackageReference Include="Microsoft.AspNetCore.WebUtilities" Version="2.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
     <PackageReference Include="ServiceStack.Text.Core" Version="1.0.44" />


### PR DESCRIPTION
The `await` calls in this library were missing `ConfigureAwait(false)`. This will result in a deadlock when trying to [block on these methods](https://blog.stephencleary.com/2012/07/dont-block-on-async-code.html) (e.g. accessing `Result`) when there's a `SynchronizationContext` (as is the case for ASP.NET Web Forms/MVC/Web API, WPF, Windows Forms, etc., though not for ASP.NET Core or Console apps).

Adding `ConfigureAwait(false)` also gives a [small performance benefit](https://msdn.microsoft.com/en-us/magazine/jj991977.aspx).

I added the [ConfigureAwaitChecker Analyzer](https://www.nuget.org/packages/ConfigureAwaitChecker.Analyzer/) to the project to help avoid this issue re-appearing.