### PR TITLE
bugfix/missing-payroll-constructor-params

### DIFF
--- a/Xero.Api/Infrastructure/Applications/Private/AmericanPayroll.cs
+++ b/Xero.Api/Infrastructure/Applications/Private/AmericanPayroll.cs
@@ -13,7 +13,7 @@ namespace Xero.Api.Infrastructure.Applications.Private
         }
 
         public AmericanPayroll(IAuthenticator authenticator, bool includeRateLimiter = false)
-            : base(authenticator, rateLimiter: includeRateLimiter ? new RateLimiter.RateLimiter() : null)
+            : base(authenticator, null, rateLimiter: includeRateLimiter ? new RateLimiter.RateLimiter() : null)
         {
         }
     }

--- a/Xero.Api/Infrastructure/Applications/Private/AustralianPayroll.cs
+++ b/Xero.Api/Infrastructure/Applications/Private/AustralianPayroll.cs
@@ -13,7 +13,7 @@ namespace Xero.Api.Infrastructure.Applications.Private
         }
 
         public AustralianPayroll(IAuthenticator authenticator, bool includeRateLimiter = false)
-            : base(authenticator, rateLimiter: includeRateLimiter ? new RateLimiter.RateLimiter() : null)
+            : base(authenticator, null, rateLimiter: includeRateLimiter ? new RateLimiter.RateLimiter() : null)
         {
         }
     }

--- a/Xero.Api/Payroll/AmericanPayroll.cs
+++ b/Xero.Api/Payroll/AmericanPayroll.cs
@@ -17,8 +17,8 @@ namespace Xero.Api.Payroll
             Connect();
         }
 
-        public AmericanPayroll(IAuthenticator auth, IUser user = null, IConsumer consumer = null, IRateLimiter rateLimiter = null)
-            : base(auth, user, consumer, rateLimiter)
+        public AmericanPayroll(string baseUrl, IAuthenticator auth, IUser user = null, IConsumer consumer = null, IRateLimiter rateLimiter = null)
+            : base(baseUrl, auth, user, consumer, rateLimiter)
         {
             Connect();
         }

--- a/Xero.Api/Payroll/AmericanPayroll.cs
+++ b/Xero.Api/Payroll/AmericanPayroll.cs
@@ -17,6 +17,13 @@ namespace Xero.Api.Payroll
             Connect();
         }
 
+        public AmericanPayroll(IAuthenticator auth, IUser user = null, IConsumer consumer = null, IRateLimiter rateLimiter = null)
+            : base(auth, user, consumer, rateLimiter)
+        {
+            Connect();
+        }
+
+
         public WorkLocationsEndpoint WorkLocations { get; private set; }
         public PayItemsEndpoint PayItems { get; private set; }
         public PayStubsEndpoint PayStubs { get; private set; }
@@ -35,7 +42,7 @@ namespace Xero.Api.Payroll
             Employees = new EmployeesEndpoint(Client);
             PayRuns = new PayRunsEndpoint(Client);
             Settings = new SettingsEndpoint(Client);
-            Timesheets = new TimesheetsEndpoint(Client);            
+            Timesheets = new TimesheetsEndpoint(Client);
         }
 
         // Note: Due to the immutability of endpoints, If you want to use filtering etc you will need to make requests via the endpoints themselves, not using the sugar methods below

--- a/Xero.Api/Payroll/AustralianPayroll.cs
+++ b/Xero.Api/Payroll/AustralianPayroll.cs
@@ -17,8 +17,8 @@ namespace Xero.Api.Payroll
             Connect();
         }
 
-        public AustralianPayroll(IAuthenticator auth, IUser user = null, IConsumer consumer = null, IRateLimiter rateLimiter = null)
-            : base(auth, user, consumer, rateLimiter)
+        public AustralianPayroll(string baseUrl, IAuthenticator auth, IUser user = null, IConsumer consumer = null, IRateLimiter rateLimiter = null)
+            : base(baseUrl, auth, user, consumer, rateLimiter)
         {
             Connect();
         }

--- a/Xero.Api/Payroll/AustralianPayroll.cs
+++ b/Xero.Api/Payroll/AustralianPayroll.cs
@@ -17,6 +17,12 @@ namespace Xero.Api.Payroll
             Connect();
         }
 
+        public AustralianPayroll(IAuthenticator auth, IUser user = null, IConsumer consumer = null, IRateLimiter rateLimiter = null)
+            : base(auth, user, consumer, rateLimiter)
+        {
+            Connect();
+        }
+
         public SuperFundsEndpoint SuperFunds { get; set; }
         public SuperFundProductsEndpoint SuperFundProducts { get; set; }
         public LeaveApplicationsEndpoint LeaveApplications { get; set; }

--- a/Xero.Api/Payroll/Common/PayrollApi.cs
+++ b/Xero.Api/Payroll/Common/PayrollApi.cs
@@ -14,8 +14,8 @@ namespace Xero.Api.Payroll.Common
         {
         }
 
-        protected PayrollApi(IAuthenticator auth, IUser user = null, IConsumer consumer = null, IRateLimiter rateLimiter = null)
-            : base(ApplicationSettings.BaseUrl, auth, consumer, user, rateLimiter)
+        protected PayrollApi(string baseUrl, IAuthenticator auth, IUser user = null, IConsumer consumer = null, IRateLimiter rateLimiter = null)
+            : base(baseUrl, auth, consumer, user, rateLimiter)
         {
         }
     }

--- a/Xero.Api/Payroll/Common/PayrollApi.cs
+++ b/Xero.Api/Payroll/Common/PayrollApi.cs
@@ -13,5 +13,10 @@ namespace Xero.Api.Payroll.Common
             : base(ApplicationSettings.BaseUrl, auth, new Consumer(ApplicationSettings.ConsumerKey, ApplicationSettings.ConsumerSecret), user, rateLimiter)
         {
         }
+
+        protected PayrollApi(IAuthenticator auth, IUser user = null, IConsumer consumer = null, IRateLimiter rateLimiter = null)
+            : base(ApplicationSettings.BaseUrl, auth, consumer, user, rateLimiter)
+        {
+        }
     }
 }


### PR DESCRIPTION
Added overload constructor for `PayrollApi`, `AustralianPayroll` & `AmericanPayroll` that accepts all allowed Payroll args.

This fixes issue #41 