### PR TITLE
Add XeroApiAppType enum

### DIFF
--- a/Xero.Api.Example.Console/Program.cs
+++ b/Xero.Api.Example.Console/Program.cs
@@ -19,13 +19,13 @@ namespace Xero.Api.Example.Console
         {
             var settings = new XeroApiSettings();
 
-            switch (settings.AppType.ToLower())
+            switch (settings.AppType)
             {
-                case "private":
+                case XeroApiAppType.Private:
                     return PrivateApp();
-                case "public":
+                case XeroApiAppType.Public:
                     return PublicApp();
-                case "partner":
+                case XeroApiAppType.Partner:
                     return PartnerApp();
                 default: throw new ApplicationException("AppType did not match one of: private, public, partner");
             }

--- a/Xero.Api.Example.MVC/Authenticators/PartnerMvcAuthenticator.cs
+++ b/Xero.Api.Example.MVC/Authenticators/PartnerMvcAuthenticator.cs
@@ -19,7 +19,7 @@ namespace Xero.Api.Example.MVC.Authenticators
         public PartnerMvcAuthenticator(ITokenStoreAsync requestTokenStore, ITokenStoreAsync accessTokenStore, IXeroApiSettings xeroApiSettings)
             : base(accessTokenStore, xeroApiSettings)
         {
-            _consumer = new Consumer(ApplicationSettings.ConsumerKey, ApplicationSettings.ConsumerSecret);
+            _consumer = new Consumer(xeroApiSettings.ConsumerKey, xeroApiSettings.ConsumerSecret);
             _requestTokenStore = requestTokenStore;
         }
 

--- a/Xero.Api.Example.MVC/Authenticators/PublicMvcAuthenticator.cs
+++ b/Xero.Api.Example.MVC/Authenticators/PublicMvcAuthenticator.cs
@@ -20,7 +20,7 @@ namespace Xero.Api.Example.MVC.Authenticators
         public PublicMvcAuthenticator(ITokenStoreAsync requestTokenStore, ITokenStoreAsync accessTokenStore, IXeroApiSettings xeroApiSettings)
             : base(accessTokenStore, xeroApiSettings)
         {
-            _consumer = new Consumer(ApplicationSettings.ConsumerKey, ApplicationSettings.ConsumerSecret);
+            _consumer = new Consumer(xeroApiSettings.ConsumerKey, xeroApiSettings.ConsumerSecret);
             _requestTokenStore = requestTokenStore;
         }
 

--- a/Xero.Api.Example.MVC/Helpers/XeroApiHelper.cs
+++ b/Xero.Api.Example.MVC/Helpers/XeroApiHelper.cs
@@ -35,18 +35,18 @@ namespace Xero.Api.Example.MVC.Helpers
             var requestTokenStore = new MemoryTokenStore();
 
             // Set the application settings with an authenticator relevant to your app type 
-            switch (applicationSettings.AppType.ToLower())
+            switch (applicationSettings.AppType)
             {
-                case "public":
+                case XeroApiAppType.Public:
                     _authenticator = new PublicMvcAuthenticator(requestTokenStore, accessTokenStore);
                     break;
-                case "partner":
+                case XeroApiAppType.Partner:
                     _authenticator = new PartnerMvcAuthenticator(requestTokenStore, accessTokenStore);
                     break;
-                case "private":
-                    throw new ApplicationException("MVC cannot be used with private applications");
-                case "default":
-                    throw new ApplicationException("AppType did not match one of: public, partner");
+                case XeroApiAppType.Private:
+                    throw new ApplicationException("MVC cannot be used with private applications.");
+                default:
+                    throw new ApplicationException("Unknown app type.");
             }
 
             return _authenticator;

--- a/Xero.Api.Example.MVC/Startup.cs
+++ b/Xero.Api.Example.MVC/Startup.cs
@@ -12,7 +12,7 @@ namespace Xero.Api.Example.MVC
             Configuration = configuration;
             var builder = new ConfigurationBuilder()
                 .SetBasePath(env.ContentRootPath)
-                .AddJsonFile("appsettings.json", optional: true, reloadOnChange: true)
+                .AddJsonFile("appsettings.json", optional: true)
                 .AddJsonFile($"appsettings.{env.EnvironmentName}.json", optional: true);
 
             builder.AddEnvironmentVariables();
@@ -21,9 +21,8 @@ namespace Xero.Api.Example.MVC
             {
                 builder.AddUserSecrets<Startup>();
             }
-            Configuration = builder.Build();
 
-           
+            Configuration = builder.Build();
         }
 
         public IConfiguration Configuration { get; }
@@ -48,7 +47,6 @@ namespace Xero.Api.Example.MVC
             {
                 app.UseExceptionHandler("/Home/Error");
             }
-           
 
             app.UseStaticFiles();
 

--- a/Xero.Api/IXeroApiSettings.cs
+++ b/Xero.Api/IXeroApiSettings.cs
@@ -14,8 +14,6 @@
 
         string SigningCertificatePassword { get; }
 
-        string AppType { get; }
-
-        bool IsPartnerApp { get; }
+        XeroApiAppType AppType { get; }
     }
 }

--- a/Xero.Api/Infrastructure/Authenticators/PartnerAuthenticatorBase.cs
+++ b/Xero.Api/Infrastructure/Authenticators/PartnerAuthenticatorBase.cs
@@ -13,7 +13,7 @@ namespace Xero.Api.Infrastructure.Authenticators
         protected PartnerAuthenticatorBase(ITokenStoreAsync store, IXeroApiSettings applicationSettings)
             : base(store, applicationSettings)
         {
-            _signingCertificate = new X509Certificate2(ApplicationSettings.SigningCertificatePath, ApplicationSettings.SigningCertificatePassword, X509KeyStorageFlags.MachineKeySet);
+            _signingCertificate = new X509Certificate2(applicationSettings.SigningCertificatePath, applicationSettings.SigningCertificatePassword, X509KeyStorageFlags.MachineKeySet);
         }
 
         protected override string CreateSignature(IToken token, string verb, Uri uri, string verifier, bool renewToken = false, string callback = null)

--- a/Xero.Api/Infrastructure/Authenticators/TokenStoreAuthenticatorBase.cs
+++ b/Xero.Api/Infrastructure/Authenticators/TokenStoreAuthenticatorBase.cs
@@ -8,10 +8,8 @@ namespace Xero.Api.Infrastructure.Authenticators
 {
     public abstract class TokenStoreAuthenticatorBase : IAuthenticator
     {
-        protected readonly IXeroApiSettings ApplicationSettings;
-
-        protected string BaseUri => ApplicationSettings.BaseUrl;
-        protected string CallBackUri => ApplicationSettings.CallbackUrl;
+        protected readonly string BaseUri;
+        protected readonly string CallBackUri;
         protected ITokenStoreAsync Store { get; set; }
 
         private OAuthTokens _tokens;
@@ -22,7 +20,8 @@ namespace Xero.Api.Infrastructure.Authenticators
         protected TokenStoreAuthenticatorBase(ITokenStoreAsync store, IXeroApiSettings applicationSettings)
         {
             Store = store;
-            ApplicationSettings = applicationSettings;
+            BaseUri = applicationSettings.BaseUrl;
+            CallBackUri = applicationSettings.CallbackUrl;
         }
 
         protected abstract string AuthorizeUser(IToken oauthToken, string scope = null, bool redirectOnError = false);

--- a/Xero.Api/XeroApiAppType.cs
+++ b/Xero.Api/XeroApiAppType.cs
@@ -1,0 +1,9 @@
+﻿namespace Xero.Api
+{
+    public enum XeroApiAppType
+    {
+        Private,
+        Public,
+        Partner,
+    }
+}

--- a/Xero.Api/XeroApiSettings.cs
+++ b/Xero.Api/XeroApiSettings.cs
@@ -5,34 +5,44 @@ namespace Xero.Api
 {
     public class XeroApiSettings : IXeroApiSettings
     {
-        public IConfigurationSection ApiSettings { get; set; }
-
         public XeroApiSettings(string path)
         {
             var builder = new ConfigurationBuilder()
                 .AddJsonFile(path)
                 .Build();
 
-            ApiSettings = builder.GetSection("XeroApi");
+            var apiSettings = builder.GetSection("XeroApi");
+
+            BaseUrl = apiSettings["BaseUrl"];
+            CallbackUrl = apiSettings["CallbackUrl"];
+            ConsumerKey = apiSettings["ConsumerKey"];
+            ConsumerSecret = apiSettings["ConsumerSecret"];
+            SigningCertificatePath = apiSettings["SigningCertPath"];
+            SigningCertificatePassword = apiSettings["SigningCertPassword"];
+
+            if (!Enum.TryParse(apiSettings["AppType"], true, out XeroApiAppType appType))
+            {
+                throw new ArgumentOutOfRangeException(nameof(apiSettings), apiSettings["AppType"], "AppType did not match one of: private, public, partner");
+            }
+
+            AppType = appType;
         }
         public XeroApiSettings() : this("appsettings.json")
         {
         }
 
-        public string BaseUrl => ApiSettings["BaseUrl"];
+        public string BaseUrl { get; }
 
-        public string CallbackUrl => ApiSettings["CallbackUrl"];
+        public string CallbackUrl { get; }
 
-        public string ConsumerKey => ApiSettings["ConsumerKey"];
+        public string ConsumerKey { get; }
 
-        public string ConsumerSecret => ApiSettings["ConsumerSecret"];
+        public string ConsumerSecret { get; }
 
-        public string SigningCertificatePath => ApiSettings["SigningCertPath"];
+        public string SigningCertificatePath { get; }
 
-        public string SigningCertificatePassword => ApiSettings["SigningCertPassword"];
+        public string SigningCertificatePassword { get; }
 
-        public string AppType => ApiSettings["AppType"];
-
-        public bool IsPartnerApp => AppType?.Equals("partner", StringComparison.OrdinalIgnoreCase) ?? false;
+        public XeroApiAppType AppType { get; }
     }
 }


### PR DESCRIPTION
I changed the type of `IXeroApiSettings.AppType` from `string` to a new enum type `XeroApiAppType` to make it clearer what options are available. I also removed the seemingly redundant `IsPartnerApp` property.