### PR TITLE
Make RateType always emitted

### DIFF
--- a/Xero.Api/Payroll/Australia/Model/EarningsRate.cs
+++ b/Xero.Api/Payroll/Australia/Model/EarningsRate.cs
@@ -17,7 +17,7 @@ namespace Xero.Api.Payroll.Australia.Model
         [DataMember]
         public EarningsType EarningsType { get; set; }
 
-        [DataMember(EmitDefaultValue = false)]
+        [DataMember]
         public RateType RateType { get; set; }
 
         [DataMember]


### PR DESCRIPTION
This resolves the issue in #59 where the `RateType` field is not emitted when it has the default value of FIXEDAMOUNT or 0. Without this change, you cannot even update earnings items in the basic Xero Demo account as it causes a validation error.