### PR TITLE
Use existing configuration

### DIFF
--- a/Xero.Api/XeroApiSettings.cs
+++ b/Xero.Api/XeroApiSettings.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using Microsoft.Extensions.Configuration;
 
 namespace Xero.Api
@@ -10,8 +10,19 @@ namespace Xero.Api
             var builder = new ConfigurationBuilder()
                 .AddJsonFile(path)
                 .Build();
-
-            var apiSettings = builder.GetSection("XeroApi");
+                
+            Load(builder);
+        }
+        public XeroApiSettings(IConfiguration config)
+        {
+            Load(config);
+        }        
+        public XeroApiSettings() : this("appsettings.json")
+        {
+        }
+        private void Load(IConfiguration config)
+        {
+            var apiSettings = config.GetSection("XeroApi");
 
             BaseUrl = apiSettings["BaseUrl"];
             CallbackUrl = apiSettings["CallbackUrl"];
@@ -25,24 +36,21 @@ namespace Xero.Api
                 throw new ArgumentOutOfRangeException(nameof(apiSettings), apiSettings["AppType"], "AppType did not match one of: private, public, partner");
             }
 
-            AppType = appType;
+            AppType = appType;        
         }
-        public XeroApiSettings() : this("appsettings.json")
-        {
-        }
+        
+        public string BaseUrl { private set; get; }
 
-        public string BaseUrl { get; }
+        public string CallbackUrl { private set; get; }
 
-        public string CallbackUrl { get; }
+        public string ConsumerKey { private set; get; }
 
-        public string ConsumerKey { get; }
+        public string ConsumerSecret { private set; get; }
 
-        public string ConsumerSecret { get; }
+        public string SigningCertificatePath { private set; get; }
 
-        public string SigningCertificatePath { get; }
+        public string SigningCertificatePassword { private set; get; }
 
-        public string SigningCertificatePassword { get; }
-
-        public XeroApiAppType AppType { get; }
+        public XeroApiAppType AppType { private set; get; }
     }
 }


### PR DESCRIPTION
Passing in a path filename is not ideal when the configuration has already been loaded, when debugging a .net core website its looking for  "appsettings.json" which is not saved in the build directory. Also for ease of configuration profiles e.g. "appsettings.Development.json", "appsettings.Production.json" etc.