### PR TITLE
Added HasUpdatedDate base class to Timesheet model.

### DIFF
--- a/Xero.Api/Payroll/Australia/Model/Timesheet.cs
+++ b/Xero.Api/Payroll/Australia/Model/Timesheet.cs
@@ -1,12 +1,13 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Runtime.Serialization;
+using Xero.Api.Common;
 using Xero.Api.Payroll.Australia.Model.Status;
 
 namespace Xero.Api.Payroll.Australia.Model
 {
-    [DataContract(Namespace="")]
-    public class Timesheet
+    [DataContract(Namespace = "")]
+    public class Timesheet : HasUpdatedDate
     {
         [DataMember(Name = "TimesheetID", EmitDefaultValue = false)]
         public Guid Id { get; set; }


### PR DESCRIPTION
In the [Payroll API documentation](https://developer.xero.com/documentation/payroll-api/timesheets) I noticed that UpdatedDateUTC was in the Timesheet response, but wasn't in the Timesheet model. To provide for this I have inherited from HasUpdatedDate, as was the style at the time.