### PR TITLE
Move SummarizeErrors to XeroUpdateEndpoint and facilitate mocking

### DIFF
--- a/Xero.Api/Core/Endpoints/Base/IXeroCreateEndpoint.cs
+++ b/Xero.Api/Core/Endpoints/Base/IXeroCreateEndpoint.cs
@@ -13,6 +13,5 @@ namespace Xero.Api.Core.Endpoints.Base
     {
         Task<IEnumerable<TResult>> CreateAsync(IEnumerable<TResult> items);
         Task<TResult> CreateAsync(TResult item);
-        T SummarizeErrors(bool summarize);
     }
 }

--- a/Xero.Api/Core/Endpoints/Base/IXeroUpdateEndpoint.cs
+++ b/Xero.Api/Core/Endpoints/Base/IXeroUpdateEndpoint.cs
@@ -13,5 +13,6 @@ namespace Xero.Api.Core.Endpoints.Base
     {
         Task<IEnumerable<TResult>> UpdateAsync(IEnumerable<TResult> items);
         Task<TResult> UpdateAsync(TResult item);
+        IXeroUpdateEndpoint<T, TResult, TRequest, TResponse>  SummarizeErrors(bool summarize);
     }
 }

--- a/Xero.Api/Core/Endpoints/Base/XeroCreateEndpoint.cs
+++ b/Xero.Api/Core/Endpoints/Base/XeroCreateEndpoint.cs
@@ -28,12 +28,7 @@ namespace Xero.Api.Core.Endpoints.Base
 
         public async Task<TResult> CreateAsync(TResult item)
         {
-            return (await CreateAsync(new[] { item }).ConfigureAwait(false)).First();
-        }
-
-        public T SummarizeErrors(bool summarize)
-        {
-            return AddParameter("summarizeErrors", summarize);
+            return (await CreateAsync(new[] {item}).ConfigureAwait(false)).First();
         }
 
         protected async Task<IEnumerable<TResult>> PutAsync(TRequest data)

--- a/Xero.Api/Core/Endpoints/Base/XeroUpdateEndpoint.cs
+++ b/Xero.Api/Core/Endpoints/Base/XeroUpdateEndpoint.cs
@@ -42,5 +42,10 @@ namespace Xero.Api.Core.Endpoints.Base
                 ClearQueryString();
             }
         }
+        
+        public IXeroUpdateEndpoint<T, TResult, TRequest, TResponse>  SummarizeErrors(bool summarize)
+        {
+            return (IXeroUpdateEndpoint<T, TResult, TRequest, TResponse>) AddParameter("summarizeErrors", summarize);
+        }
     }
 }


### PR DESCRIPTION
This allows calling SummarizeErrors() on IXeroUpdateEndpoint and IXeroCreateEndpoint and returns interfaces to facilitate mocking of the method when using the SDK. 