### PR TITLE
Adding missing enums

### DIFF
--- a/Xero.NetStandard.OAuth2/Model/ManualJournal.cs
+++ b/Xero.NetStandard.OAuth2/Model/ManualJournal.cs
@@ -66,6 +66,12 @@ namespace Xero.NetStandard.OAuth2.Model
             /// </summary>
             [EnumMember(Value = "VOIDED")]
             VOIDED = 4
+			
+			/// <summary>
+            /// Enum ARCHIVED for value: ARCHIVED
+            /// </summary>
+            [EnumMember(Value = "ARCHIVED")]
+            ARCHIVED = 5
 
         }
 

--- a/Xero.NetStandard.OAuth2/Model/Organisation.cs
+++ b/Xero.NetStandard.OAuth2/Model/Organisation.cs
@@ -357,6 +357,12 @@ namespace Xero.NetStandard.OAuth2.Model
             [EnumMember(Value = "YEARLY")]
             YEARLY = 14
 
+			            /// <summary>
+            /// Enum NONE for value: NONE
+            /// </summary>
+            [EnumMember(Value = "NONE")]
+            NONE = 15
+			
         }
 
         /// <summary>


### PR DESCRIPTION
The following enums were missing from the model:

- ARCHIVED status for ManualJournal
- NONE sales tax period for organisation SalesTaxPeriodEnum

I found this while debugging my asp.net core app. Error was being thrown on GetManualJournalsAsync and GetOrganisationsAsync that was not obvious until I looked at the code.