### PR TITLE
Added the error content string to exception

### DIFF
--- a/Xero.NetStandard.OAuth2/Client/ApiException.cs
+++ b/Xero.NetStandard.OAuth2/Client/ApiException.cs
@@ -29,6 +29,12 @@ namespace Xero.NetStandard.OAuth2.Client
         /// </summary>
         /// <value>The error content (Http response body).</value>
         public dynamic ErrorContent { get; private set; }
+        
+        /// <summary>
+        /// Get or sets the error content as string 
+        /// </summary>
+        /// <value>The error content (Http response body) as a string</value>
+        public string ErrorContentString { get; private set; }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ApiException"/> class.
@@ -56,6 +62,20 @@ namespace Xero.NetStandard.OAuth2.Client
             this.ErrorCode = errorCode;
             this.ErrorContent = errorContent;
         }
+        
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ApiException"/> class.
+        /// </summary>
+        /// <param name="errorCode">HTTP status code.</param>
+        /// <param name="message">Error message.</param>
+        /// <param name="errorContent">Error content.</param>
+        public ApiException(int errorCode, string message, dynamic errorContent = null, string errorContentString = null) : base(message)
+        {
+            this.ErrorCode = errorCode;
+            this.ErrorContent = errorContent;
+            this.ErrorContentString = errorContentString;
+        }
+        
     }
 
 }

--- a/Xero.NetStandard.OAuth2/Client/Configuration.cs
+++ b/Xero.NetStandard.OAuth2/Client/Configuration.cs
@@ -67,7 +67,7 @@ namespace Xero.NetStandard.OAuth2.Client
                         }
 
                     }
-                    return new ApiException(status, string.Format("{0}:{1}", error.Message, validationBuilder.ToString()), error);
+                    return new ApiException(status, string.Format("{0}:{1}", error.Message, validationBuilder.ToString()), error,response.Content.ToString());
                 case int code when status > 400:
                     return new ApiException(status,
                                        string.Format("Error calling {0}: {1}", methodName, response.Content),


### PR DESCRIPTION
@jenksguo  for issue #156 

Added the error content string to the exception to be able to pull it out and see which items have failed. 

I have added the error string as it has the details that I need. However am I recreating what could be a typed value in the Error Class for Elements? Adding the string won't break anyone elses code but I imagine no one is needing to use the ErrorContent class at the moment.