### PR TITLE
Fix ihttpclientfactory v1 0 0 release

### DIFF
--- a/Xero.NetStandard.OAuth2Client/Xero.NetStandard.OAuth2Client.csproj
+++ b/Xero.NetStandard.OAuth2Client/Xero.NetStandard.OAuth2Client.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <PackageId>Xero.NetStandard.OAuth2Client</PackageId>
-    <Version>1.0.0</Version>
+    <Version>1.1.0</Version>
     <Authors>Xero</Authors>
     <Company>Xero</Company>
     <PackageLicenseUrl>https://github.com/XeroAPI/Xero-NetStandard/</PackageLicenseUrl>

--- a/Xero.NetStandard.OAuth2Client/Xero.NetStandard.OAuth2Client.csproj
+++ b/Xero.NetStandard.OAuth2Client/Xero.NetStandard.OAuth2Client.csproj
@@ -12,6 +12,6 @@
     <PackageTags>xero;api;sdk;oauth2;oauth2.0</PackageTags>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="IdentityModel" Version="3.10.10" />
+    <PackageReference Include="IdentityModel" Version="4.0.0" />
   </ItemGroup>
 </Project>

--- a/Xero.NetStandard.OAuth2Client/src/Client/IXeroClient.cs
+++ b/Xero.NetStandard.OAuth2Client/src/Client/IXeroClient.cs
@@ -14,7 +14,6 @@ namespace Xero.NetStandard.OAuth2.Client
         Task<IXeroToken> RequestAccessTokenAsync(string code);
         Task<IXeroToken> RequestAccessTokenPkceAsync(string code, string codeVerifier);
         Task<IXeroToken> RefreshAccessTokenAsync(IXeroToken xeroToken);
-        Task<IXeroToken> RequestXeroTokenAsync(string code);
         Task<IXeroToken> GetCurrentValidTokenAsync(IXeroToken xeroToken);
         Task<List<Tenant>> GetConnectionsAsync(IXeroToken xeroToken);
         Task DeleteConnectionAsync(IXeroToken xeroToken, Tenant xeroTenant);

--- a/Xero.NetStandard.OAuth2Client/src/Client/XeroClient.cs
+++ b/Xero.NetStandard.OAuth2Client/src/Client/XeroClient.cs
@@ -129,7 +129,7 @@ namespace Xero.NetStandard.OAuth2.Client
         /// </summary>
         /// <param name="code">Code returned from callback</param>
         /// <returns></returns>
-        public async Task<IXeroToken> RequestXeroTokenAsync(string code)
+        public async Task<IXeroToken> RequestAccessTokenAsync(string code)
         {
             var response = await _httpClient.RequestAuthorizationCodeTokenAsync(new AuthorizationCodeTokenRequest
             {


### PR DESCRIPTION
A fix for: 
1. issue with PKCE method still using IHttpClientFactory dependency
2. rename RequestXeroTokenAsync() to RequestAccessTokenAsync()
3. updated IdentityModel version to 4.0.0 as requested by [this issue](https://github.com/XeroAPI/Xero-NetStandard/issues/126)