### PR TITLE
Add test project to OAuth2 solution file

### DIFF
--- a/Xero.NetStandard.OAuth2.sln
+++ b/Xero.NetStandard.OAuth2.sln
@@ -7,6 +7,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Xero.NetStandard.OAuth2", "
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Xero.NetStandard.OAuth2Client", "Xero.NetStandard.OAuth2Client\Xero.NetStandard.OAuth2Client.csproj", "{0FCA1916-DB88-41A8-A6E1-A23F837D3A64}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Xero.NetStandard.OAuth2.Test", "Xero.NetStandard.OAuth2.Test\Xero.NetStandard.OAuth2.Test.csproj", "{0E5C75A1-B6EE-43D9-B8C2-CDB862658E36}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -21,6 +23,10 @@ Global
 		{0FCA1916-DB88-41A8-A6E1-A23F837D3A64}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{0FCA1916-DB88-41A8-A6E1-A23F837D3A64}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{0FCA1916-DB88-41A8-A6E1-A23F837D3A64}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0E5C75A1-B6EE-43D9-B8C2-CDB862658E36}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0E5C75A1-B6EE-43D9-B8C2-CDB862658E36}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0E5C75A1-B6EE-43D9-B8C2-CDB862658E36}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0E5C75A1-B6EE-43D9-B8C2-CDB862658E36}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Adding the test project to the solution. Has the following benefits:
- Intellisense in the test project
- can run `dotnet test` from solution root directory
- running `dotnet build` will build all projects -- helps prevent against committing broken tests