### PR TITLE
Change FieldId type from Guid to string

### DIFF
--- a/Xero.NetStandard.OAuth2/Model/Accounting/ReportFields.cs
+++ b/Xero.NetStandard.OAuth2/Model/Accounting/ReportFields.cs
@@ -36,7 +36,7 @@ namespace Xero.NetStandard.OAuth2.Model.Accounting
         /// Gets or Sets FieldID
         /// </summary>
         [DataMember(Name="FieldID", EmitDefaultValue=false)]
-        public Guid? FieldID { get; set; }
+        public string FieldID { get; set; }
 
         /// <summary>
         /// Gets or Sets Description


### PR DESCRIPTION
Certain reports, for example the BAS Report (https://api.xero.com/api.xro/2.0/Reports), return field ids containing string values such as 'ABN' instead of a GUID.