### PR TITLE
Add example test using CustomJsonCodec to test deserialization

### DIFF
--- a/Xero.NetStandard.OAuth2.Test/Model/Accounting/InvoiceTests.cs
+++ b/Xero.NetStandard.OAuth2.Test/Model/Accounting/InvoiceTests.cs
@@ -20,6 +20,8 @@ using Xero.NetStandard.OAuth2.Model;
 using Xero.NetStandard.OAuth2.Client;
 using System.Reflection;
 using Newtonsoft.Json;
+using RestSharp;
+using Xero.NetStandard.OAuth2.Model.Accounting;
 
 namespace Xero.NetStandard.OAuth2.Test.Model.Accounting
 {
@@ -186,13 +188,24 @@ namespace Xero.NetStandard.OAuth2.Test.Model.Accounting
             // TODO unit test for the property 'PlannedPaymentDate'
         }
         /// <summary>
-        /// Test the property 'CISDeduction'
+        /// Test that the property 'CISDeduction' deserializes correctly
         /// </summary>
-        [Fact]
-        public void CISDeductionTest()
+        [Theory]
+        [InlineData("20.00")]
+        [InlineData("20")]
+        public void CISDeduction_IsNumber_DeserializesCorrectly(string number)
         {
-            // TODO unit test for the property 'CISDeduction'
+            var response = new RestResponse();
+            response.Content = $@"{{
+                ""CISDeduction"": {number}
+            }}";
+
+            var deserializer = new CustomJsonCodec(new Configuration());
+            var invoices = deserializer.Deserialize<Invoice>(response);
+
+            Assert.Equal(20, invoices.CISDeduction);
         }
+        
         /// <summary>
         /// Test the property 'SubTotal'
         /// </summary>

--- a/Xero.NetStandard.OAuth2/Client/ApiClient.cs
+++ b/Xero.NetStandard.OAuth2/Client/ApiClient.cs
@@ -28,6 +28,7 @@ using RestSharp.Deserializers;
 using ErrorEventArgs = Newtonsoft.Json.Serialization.ErrorEventArgs;
 using RestSharpMethod = RestSharp.Method;
 
+[assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Xero.NetStandard.OAuth2.Test")]
 namespace Xero.NetStandard.OAuth2.Client
 {
     /// <summary>


### PR DESCRIPTION
Add first test for testing deserialization locally and directly.

Tests requiring a more complex JSON document can use test helpers as required. 