### PR TITLE
Add CustomStringEnumConverter class to support deserialising null enums

### DIFF
--- a/Xero.NetStandard.OAuth2/Client/ApiClient.cs
+++ b/Xero.NetStandard.OAuth2/Client/ApiClient.cs
@@ -23,6 +23,7 @@ using System.Runtime.Serialization.Formatters;
 using System.Text;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
+using Newtonsoft.Json.Converters;
 using RestSharp;
 using RestSharp.Deserializers;
 using ErrorEventArgs = Newtonsoft.Json.Serialization.ErrorEventArgs;
@@ -172,6 +173,23 @@ namespace Xero.NetStandard.OAuth2.Client
             set { throw new InvalidOperationException("Not allowed to set content type."); }
         }
     }
+
+    /// <summary>
+    /// Override class used to support deserialising null enum values
+    /// </summary>
+    public class CustomStringEnumConverter : StringEnumConverter
+    {
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            if (objectType.IsEnum && reader.Value == null)
+            {
+                return Activator.CreateInstance(objectType);
+            }
+
+            return base.ReadJson(reader, objectType, existingValue, serializer);
+        }
+    }
+
     /// <summary>
     /// Provides a default implementation of an Api client (both synchronous and asynchronous implementatios),
     /// encapsulating general REST accessor use cases.

--- a/Xero.NetStandard.OAuth2/Model/Accounting/Account.cs
+++ b/Xero.NetStandard.OAuth2/Model/Accounting/Account.cs
@@ -40,7 +40,7 @@ namespace Xero.NetStandard.OAuth2.Model.Accounting
         /// Accounts with a status of ACTIVE can be updated to ARCHIVED. See Account Status Codes
         /// </summary>
         /// <value>Accounts with a status of ACTIVE can be updated to ARCHIVED. See Account Status Codes</value>
-        [JsonConverter(typeof(StringEnumConverter))]
+        [JsonConverter(typeof(Client.CustomStringEnumConverter))]
         public enum StatusEnum
         {
             /// <summary>
@@ -73,7 +73,7 @@ namespace Xero.NetStandard.OAuth2.Model.Accounting
         /// For bank accounts only. See Bank Account types
         /// </summary>
         /// <value>For bank accounts only. See Bank Account types</value>
-        [JsonConverter(typeof(StringEnumConverter))]
+        [JsonConverter(typeof(Client.CustomStringEnumConverter))]
         public enum BankAccountTypeEnum
         {
             /// <summary>
@@ -123,7 +123,7 @@ namespace Xero.NetStandard.OAuth2.Model.Accounting
         /// See Account Class Types
         /// </summary>
         /// <value>See Account Class Types</value>
-        [JsonConverter(typeof(StringEnumConverter))]
+        [JsonConverter(typeof(Client.CustomStringEnumConverter))]
         public enum ClassEnum
         {
             /// <summary>
@@ -168,7 +168,7 @@ namespace Xero.NetStandard.OAuth2.Model.Accounting
         /// If this is a system account then this element is returned. See System Account types. Note that non-system accounts may have this element set as either “” or null.
         /// </summary>
         /// <value>If this is a system account then this element is returned. See System Account types. Note that non-system accounts may have this element set as either “” or null.</value>
-        [JsonConverter(typeof(StringEnumConverter))]
+        [JsonConverter(typeof(Client.CustomStringEnumConverter))]
         public enum SystemAccountEnum
         {
             /// <summary>

--- a/Xero.NetStandard.OAuth2/Model/Accounting/AccountType.cs
+++ b/Xero.NetStandard.OAuth2/Model/Accounting/AccountType.cs
@@ -30,7 +30,7 @@ namespace Xero.NetStandard.OAuth2.Model.Accounting
     /// </summary>
     /// <value>See Account Types</value>
     
-    [JsonConverter(typeof(StringEnumConverter))]
+    [JsonConverter(typeof(Client.CustomStringEnumConverter))]
     
     public enum AccountType
     {

--- a/Xero.NetStandard.OAuth2/Model/Accounting/Action.cs
+++ b/Xero.NetStandard.OAuth2/Model/Accounting/Action.cs
@@ -35,7 +35,7 @@ namespace Xero.NetStandard.OAuth2.Model.Accounting
         /// Status of the action for this organisation
         /// </summary>
         /// <value>Status of the action for this organisation</value>
-        [JsonConverter(typeof(StringEnumConverter))]
+        [JsonConverter(typeof(Client.CustomStringEnumConverter))]
         public enum StatusEnum
         {
             /// <summary>

--- a/Xero.NetStandard.OAuth2/Model/Accounting/Address.cs
+++ b/Xero.NetStandard.OAuth2/Model/Accounting/Address.cs
@@ -35,7 +35,7 @@ namespace Xero.NetStandard.OAuth2.Model.Accounting
         /// define the type of address
         /// </summary>
         /// <value>define the type of address</value>
-        [JsonConverter(typeof(StringEnumConverter))]
+        [JsonConverter(typeof(Client.CustomStringEnumConverter))]
         public enum AddressTypeEnum
         {
             /// <summary>

--- a/Xero.NetStandard.OAuth2/Model/Accounting/BankTransaction.cs
+++ b/Xero.NetStandard.OAuth2/Model/Accounting/BankTransaction.cs
@@ -35,7 +35,7 @@ namespace Xero.NetStandard.OAuth2.Model.Accounting
         /// See Bank Transaction Types
         /// </summary>
         /// <value>See Bank Transaction Types</value>
-        [JsonConverter(typeof(StringEnumConverter))]
+        [JsonConverter(typeof(Client.CustomStringEnumConverter))]
         public enum TypeEnum
         {
             /// <summary>
@@ -103,7 +103,7 @@ namespace Xero.NetStandard.OAuth2.Model.Accounting
         /// See Bank Transaction Status Codes
         /// </summary>
         /// <value>See Bank Transaction Status Codes</value>
-        [JsonConverter(typeof(StringEnumConverter))]
+        [JsonConverter(typeof(Client.CustomStringEnumConverter))]
         public enum StatusEnum
         {
             /// <summary>

--- a/Xero.NetStandard.OAuth2/Model/Accounting/BatchPayment.cs
+++ b/Xero.NetStandard.OAuth2/Model/Accounting/BatchPayment.cs
@@ -35,7 +35,7 @@ namespace Xero.NetStandard.OAuth2.Model.Accounting
         /// PAYBATCH for bill payments or RECBATCH for sales invoice payments (read-only)
         /// </summary>
         /// <value>PAYBATCH for bill payments or RECBATCH for sales invoice payments (read-only)</value>
-        [JsonConverter(typeof(StringEnumConverter))]
+        [JsonConverter(typeof(Client.CustomStringEnumConverter))]
         public enum TypeEnum
         {
             /// <summary>
@@ -62,7 +62,7 @@ namespace Xero.NetStandard.OAuth2.Model.Accounting
         /// AUTHORISED or DELETED (read-only). New batch payments will have a status of AUTHORISED. It is not possible to delete batch payments via the API.
         /// </summary>
         /// <value>AUTHORISED or DELETED (read-only). New batch payments will have a status of AUTHORISED. It is not possible to delete batch payments via the API.</value>
-        [JsonConverter(typeof(StringEnumConverter))]
+        [JsonConverter(typeof(Client.CustomStringEnumConverter))]
         public enum StatusEnum
         {
             /// <summary>

--- a/Xero.NetStandard.OAuth2/Model/Accounting/BrandingTheme.cs
+++ b/Xero.NetStandard.OAuth2/Model/Accounting/BrandingTheme.cs
@@ -35,7 +35,7 @@ namespace Xero.NetStandard.OAuth2.Model.Accounting
         /// Always INVOICE
         /// </summary>
         /// <value>Always INVOICE</value>
-        [JsonConverter(typeof(StringEnumConverter))]
+        [JsonConverter(typeof(Client.CustomStringEnumConverter))]
         public enum TypeEnum
         {
             /// <summary>

--- a/Xero.NetStandard.OAuth2/Model/Accounting/Contact.cs
+++ b/Xero.NetStandard.OAuth2/Model/Accounting/Contact.cs
@@ -35,7 +35,7 @@ namespace Xero.NetStandard.OAuth2.Model.Accounting
         /// Current status of a contact – see contact status types
         /// </summary>
         /// <value>Current status of a contact – see contact status types</value>
-        [JsonConverter(typeof(StringEnumConverter))]
+        [JsonConverter(typeof(Client.CustomStringEnumConverter))]
         public enum ContactStatusEnum
         {
             /// <summary>

--- a/Xero.NetStandard.OAuth2/Model/Accounting/ContactGroup.cs
+++ b/Xero.NetStandard.OAuth2/Model/Accounting/ContactGroup.cs
@@ -35,7 +35,7 @@ namespace Xero.NetStandard.OAuth2.Model.Accounting
         /// The Status of a contact group. To delete a contact group update the status to DELETED. Only contact groups with a status of ACTIVE are returned on GETs.
         /// </summary>
         /// <value>The Status of a contact group. To delete a contact group update the status to DELETED. Only contact groups with a status of ACTIVE are returned on GETs.</value>
-        [JsonConverter(typeof(StringEnumConverter))]
+        [JsonConverter(typeof(Client.CustomStringEnumConverter))]
         public enum StatusEnum
         {
             /// <summary>

--- a/Xero.NetStandard.OAuth2/Model/Accounting/CountryCode.cs
+++ b/Xero.NetStandard.OAuth2/Model/Accounting/CountryCode.cs
@@ -29,7 +29,7 @@ namespace Xero.NetStandard.OAuth2.Model.Accounting
     /// Defines CountryCode
     /// </summary>
     
-    [JsonConverter(typeof(StringEnumConverter))]
+    [JsonConverter(typeof(Client.CustomStringEnumConverter))]
     
     public enum CountryCode
     {

--- a/Xero.NetStandard.OAuth2/Model/Accounting/CreditNote.cs
+++ b/Xero.NetStandard.OAuth2/Model/Accounting/CreditNote.cs
@@ -35,7 +35,7 @@ namespace Xero.NetStandard.OAuth2.Model.Accounting
         /// See Credit Note Types
         /// </summary>
         /// <value>See Credit Note Types</value>
-        [JsonConverter(typeof(StringEnumConverter))]
+        [JsonConverter(typeof(Client.CustomStringEnumConverter))]
         public enum TypeEnum
         {
             /// <summary>
@@ -62,7 +62,7 @@ namespace Xero.NetStandard.OAuth2.Model.Accounting
         /// See Credit Note Status Codes
         /// </summary>
         /// <value>See Credit Note Status Codes</value>
-        [JsonConverter(typeof(StringEnumConverter))]
+        [JsonConverter(typeof(Client.CustomStringEnumConverter))]
         public enum StatusEnum
         {
             /// <summary>

--- a/Xero.NetStandard.OAuth2/Model/Accounting/CurrencyCode.cs
+++ b/Xero.NetStandard.OAuth2/Model/Accounting/CurrencyCode.cs
@@ -30,7 +30,7 @@ namespace Xero.NetStandard.OAuth2.Model.Accounting
     /// </summary>
     /// <value>3 letter alpha code for the currency – see list of currency codes</value>
     
-    [JsonConverter(typeof(StringEnumConverter))]
+    [JsonConverter(typeof(Client.CustomStringEnumConverter))]
     
     public enum CurrencyCode
     {

--- a/Xero.NetStandard.OAuth2/Model/Accounting/Employee.cs
+++ b/Xero.NetStandard.OAuth2/Model/Accounting/Employee.cs
@@ -35,7 +35,7 @@ namespace Xero.NetStandard.OAuth2.Model.Accounting
         /// Current status of an employee – see contact status types
         /// </summary>
         /// <value>Current status of an employee – see contact status types</value>
-        [JsonConverter(typeof(StringEnumConverter))]
+        [JsonConverter(typeof(Client.CustomStringEnumConverter))]
         public enum StatusEnum
         {
             /// <summary>

--- a/Xero.NetStandard.OAuth2/Model/Accounting/ExpenseClaim.cs
+++ b/Xero.NetStandard.OAuth2/Model/Accounting/ExpenseClaim.cs
@@ -35,7 +35,7 @@ namespace Xero.NetStandard.OAuth2.Model.Accounting
         /// Current status of an expense claim – see status types
         /// </summary>
         /// <value>Current status of an expense claim – see status types</value>
-        [JsonConverter(typeof(StringEnumConverter))]
+        [JsonConverter(typeof(Client.CustomStringEnumConverter))]
         public enum StatusEnum
         {
             /// <summary>

--- a/Xero.NetStandard.OAuth2/Model/Accounting/ExternalLink.cs
+++ b/Xero.NetStandard.OAuth2/Model/Accounting/ExternalLink.cs
@@ -35,7 +35,7 @@ namespace Xero.NetStandard.OAuth2.Model.Accounting
         /// See External link types
         /// </summary>
         /// <value>See External link types</value>
-        [JsonConverter(typeof(StringEnumConverter))]
+        [JsonConverter(typeof(Client.CustomStringEnumConverter))]
         public enum LinkTypeEnum
         {
             /// <summary>

--- a/Xero.NetStandard.OAuth2/Model/Accounting/Invoice.cs
+++ b/Xero.NetStandard.OAuth2/Model/Accounting/Invoice.cs
@@ -35,7 +35,7 @@ namespace Xero.NetStandard.OAuth2.Model.Accounting
         /// See Invoice Types
         /// </summary>
         /// <value>See Invoice Types</value>
-        [JsonConverter(typeof(StringEnumConverter))]
+        [JsonConverter(typeof(Client.CustomStringEnumConverter))]
         public enum TypeEnum
         {
             /// <summary>
@@ -108,7 +108,7 @@ namespace Xero.NetStandard.OAuth2.Model.Accounting
         /// See Invoice Status Codes
         /// </summary>
         /// <value>See Invoice Status Codes</value>
-        [JsonConverter(typeof(StringEnumConverter))]
+        [JsonConverter(typeof(Client.CustomStringEnumConverter))]
         public enum StatusEnum
         {
             /// <summary>

--- a/Xero.NetStandard.OAuth2/Model/Accounting/Journal.cs
+++ b/Xero.NetStandard.OAuth2/Model/Accounting/Journal.cs
@@ -35,7 +35,7 @@ namespace Xero.NetStandard.OAuth2.Model.Accounting
         /// The journal source type. The type of transaction that created the journal
         /// </summary>
         /// <value>The journal source type. The type of transaction that created the journal</value>
-        [JsonConverter(typeof(StringEnumConverter))]
+        [JsonConverter(typeof(Client.CustomStringEnumConverter))]
         public enum SourceTypeEnum
         {
             /// <summary>

--- a/Xero.NetStandard.OAuth2/Model/Accounting/LineAmountTypes.cs
+++ b/Xero.NetStandard.OAuth2/Model/Accounting/LineAmountTypes.cs
@@ -30,7 +30,7 @@ namespace Xero.NetStandard.OAuth2.Model.Accounting
     /// </summary>
     /// <value>Line amounts are exclusive of tax by default if you don’t specify this element. See Line Amount Types</value>
     
-    [JsonConverter(typeof(StringEnumConverter))]
+    [JsonConverter(typeof(Client.CustomStringEnumConverter))]
     
     public enum LineAmountTypes
     {

--- a/Xero.NetStandard.OAuth2/Model/Accounting/LinkedTransaction.cs
+++ b/Xero.NetStandard.OAuth2/Model/Accounting/LinkedTransaction.cs
@@ -35,7 +35,7 @@ namespace Xero.NetStandard.OAuth2.Model.Accounting
         /// Filter by the combination of ContactID and Status. Get all the linked transactions that have been assigned to a particular customer and have a particular status e.g. GET /LinkedTransactions?ContactID&#x3D;4bb34b03-3378-4bb2-a0ed-6345abf3224e&amp;Status&#x3D;APPROVED.
         /// </summary>
         /// <value>Filter by the combination of ContactID and Status. Get all the linked transactions that have been assigned to a particular customer and have a particular status e.g. GET /LinkedTransactions?ContactID&#x3D;4bb34b03-3378-4bb2-a0ed-6345abf3224e&amp;Status&#x3D;APPROVED.</value>
-        [JsonConverter(typeof(StringEnumConverter))]
+        [JsonConverter(typeof(Client.CustomStringEnumConverter))]
         public enum StatusEnum
         {
             /// <summary>
@@ -80,7 +80,7 @@ namespace Xero.NetStandard.OAuth2.Model.Accounting
         /// This will always be BILLABLEEXPENSE. More types may be added in future.
         /// </summary>
         /// <value>This will always be BILLABLEEXPENSE. More types may be added in future.</value>
-        [JsonConverter(typeof(StringEnumConverter))]
+        [JsonConverter(typeof(Client.CustomStringEnumConverter))]
         public enum TypeEnum
         {
             /// <summary>
@@ -101,7 +101,7 @@ namespace Xero.NetStandard.OAuth2.Model.Accounting
         /// The Type of the source tranasction. This will be ACCPAY if the linked transaction was created from an invoice and SPEND if it was created from a bank transaction.
         /// </summary>
         /// <value>The Type of the source tranasction. This will be ACCPAY if the linked transaction was created from an invoice and SPEND if it was created from a bank transaction.</value>
-        [JsonConverter(typeof(StringEnumConverter))]
+        [JsonConverter(typeof(Client.CustomStringEnumConverter))]
         public enum SourceTransactionTypeCodeEnum
         {
             /// <summary>

--- a/Xero.NetStandard.OAuth2/Model/Accounting/ManualJournal.cs
+++ b/Xero.NetStandard.OAuth2/Model/Accounting/ManualJournal.cs
@@ -40,7 +40,7 @@ namespace Xero.NetStandard.OAuth2.Model.Accounting
         /// See Manual Journal Status Codes
         /// </summary>
         /// <value>See Manual Journal Status Codes</value>
-        [JsonConverter(typeof(StringEnumConverter))]
+        [JsonConverter(typeof(Client.CustomStringEnumConverter))]
         public enum StatusEnum
         {
             /// <summary>

--- a/Xero.NetStandard.OAuth2/Model/Accounting/Organisation.cs
+++ b/Xero.NetStandard.OAuth2/Model/Accounting/Organisation.cs
@@ -35,7 +35,7 @@ namespace Xero.NetStandard.OAuth2.Model.Accounting
         /// See Version Types
         /// </summary>
         /// <value>See Version Types</value>
-        [JsonConverter(typeof(StringEnumConverter))]
+        [JsonConverter(typeof(Client.CustomStringEnumConverter))]
         public enum VersionEnum
         {
             /// <summary>
@@ -110,7 +110,7 @@ namespace Xero.NetStandard.OAuth2.Model.Accounting
         /// Organisation Type
         /// </summary>
         /// <value>Organisation Type</value>
-        [JsonConverter(typeof(StringEnumConverter))]
+        [JsonConverter(typeof(Client.CustomStringEnumConverter))]
         public enum OrganisationTypeEnum
         {
             /// <summary>
@@ -207,7 +207,7 @@ namespace Xero.NetStandard.OAuth2.Model.Accounting
         /// The accounting basis used for tax returns. See Sales Tax Basis
         /// </summary>
         /// <value>The accounting basis used for tax returns. See Sales Tax Basis</value>
-        [JsonConverter(typeof(StringEnumConverter))]
+        [JsonConverter(typeof(Client.CustomStringEnumConverter))]
         public enum SalesTaxBasisEnum
         {
             /// <summary>
@@ -270,7 +270,7 @@ namespace Xero.NetStandard.OAuth2.Model.Accounting
         /// The frequency with which tax returns are processed. See Sales Tax Period
         /// </summary>
         /// <value>The frequency with which tax returns are processed. See Sales Tax Period</value>
-        [JsonConverter(typeof(StringEnumConverter))]
+        [JsonConverter(typeof(Client.CustomStringEnumConverter))]
         public enum SalesTaxPeriodEnum
         {
             /// <summary>
@@ -380,7 +380,7 @@ namespace Xero.NetStandard.OAuth2.Model.Accounting
         /// Organisation Entity Type
         /// </summary>
         /// <value>Organisation Entity Type</value>
-        [JsonConverter(typeof(StringEnumConverter))]
+        [JsonConverter(typeof(Client.CustomStringEnumConverter))]
         public enum OrganisationEntityTypeEnum
         {
             /// <summary>
@@ -467,7 +467,7 @@ namespace Xero.NetStandard.OAuth2.Model.Accounting
         /// Organisation Classes describe which plan the Xero organisation is on (e.g. DEMO, TRIAL, PREMIUM)
         /// </summary>
         /// <value>Organisation Classes describe which plan the Xero organisation is on (e.g. DEMO, TRIAL, PREMIUM)</value>
-        [JsonConverter(typeof(StringEnumConverter))]
+        [JsonConverter(typeof(Client.CustomStringEnumConverter))]
         public enum ClassEnum
         {
             /// <summary>
@@ -548,7 +548,7 @@ namespace Xero.NetStandard.OAuth2.Model.Accounting
         /// BUSINESS or PARTNER. Partner edition organisations are sold exclusively through accounting partners and have restricted functionality (e.g. no access to invoicing)
         /// </summary>
         /// <value>BUSINESS or PARTNER. Partner edition organisations are sold exclusively through accounting partners and have restricted functionality (e.g. no access to invoicing)</value>
-        [JsonConverter(typeof(StringEnumConverter))]
+        [JsonConverter(typeof(Client.CustomStringEnumConverter))]
         public enum EditionEnum
         {
             /// <summary>

--- a/Xero.NetStandard.OAuth2/Model/Accounting/Overpayment.cs
+++ b/Xero.NetStandard.OAuth2/Model/Accounting/Overpayment.cs
@@ -35,7 +35,7 @@ namespace Xero.NetStandard.OAuth2.Model.Accounting
         /// See Overpayment Types
         /// </summary>
         /// <value>See Overpayment Types</value>
-        [JsonConverter(typeof(StringEnumConverter))]
+        [JsonConverter(typeof(Client.CustomStringEnumConverter))]
         public enum TypeEnum
         {
             /// <summary>
@@ -68,7 +68,7 @@ namespace Xero.NetStandard.OAuth2.Model.Accounting
         /// See Overpayment Status Codes
         /// </summary>
         /// <value>See Overpayment Status Codes</value>
-        [JsonConverter(typeof(StringEnumConverter))]
+        [JsonConverter(typeof(Client.CustomStringEnumConverter))]
         public enum StatusEnum
         {
             /// <summary>

--- a/Xero.NetStandard.OAuth2/Model/Accounting/Payment.cs
+++ b/Xero.NetStandard.OAuth2/Model/Accounting/Payment.cs
@@ -35,7 +35,7 @@ namespace Xero.NetStandard.OAuth2.Model.Accounting
         /// The status of the payment.
         /// </summary>
         /// <value>The status of the payment.</value>
-        [JsonConverter(typeof(StringEnumConverter))]
+        [JsonConverter(typeof(Client.CustomStringEnumConverter))]
         public enum StatusEnum
         {
             /// <summary>
@@ -62,7 +62,7 @@ namespace Xero.NetStandard.OAuth2.Model.Accounting
         /// See Payment Types.
         /// </summary>
         /// <value>See Payment Types.</value>
-        [JsonConverter(typeof(StringEnumConverter))]
+        [JsonConverter(typeof(Client.CustomStringEnumConverter))]
         public enum PaymentTypeEnum
         {
             /// <summary>

--- a/Xero.NetStandard.OAuth2/Model/Accounting/PaymentTermType.cs
+++ b/Xero.NetStandard.OAuth2/Model/Accounting/PaymentTermType.cs
@@ -29,7 +29,7 @@ namespace Xero.NetStandard.OAuth2.Model.Accounting
     /// Defines PaymentTermType
     /// </summary>
     
-    [JsonConverter(typeof(StringEnumConverter))]
+    [JsonConverter(typeof(Client.CustomStringEnumConverter))]
     
     public enum PaymentTermType
     {

--- a/Xero.NetStandard.OAuth2/Model/Accounting/Phone.cs
+++ b/Xero.NetStandard.OAuth2/Model/Accounting/Phone.cs
@@ -34,7 +34,7 @@ namespace Xero.NetStandard.OAuth2.Model.Accounting
         /// <summary>
         /// Defines PhoneType
         /// </summary>
-        [JsonConverter(typeof(StringEnumConverter))]
+        [JsonConverter(typeof(Client.CustomStringEnumConverter))]
         public enum PhoneTypeEnum
         {
             /// <summary>

--- a/Xero.NetStandard.OAuth2/Model/Accounting/Prepayment.cs
+++ b/Xero.NetStandard.OAuth2/Model/Accounting/Prepayment.cs
@@ -35,7 +35,7 @@ namespace Xero.NetStandard.OAuth2.Model.Accounting
         /// See Prepayment Types
         /// </summary>
         /// <value>See Prepayment Types</value>
-        [JsonConverter(typeof(StringEnumConverter))]
+        [JsonConverter(typeof(Client.CustomStringEnumConverter))]
         public enum TypeEnum
         {
             /// <summary>
@@ -74,7 +74,7 @@ namespace Xero.NetStandard.OAuth2.Model.Accounting
         /// See Prepayment Status Codes
         /// </summary>
         /// <value>See Prepayment Status Codes</value>
-        [JsonConverter(typeof(StringEnumConverter))]
+        [JsonConverter(typeof(Client.CustomStringEnumConverter))]
         public enum StatusEnum
         {
             /// <summary>

--- a/Xero.NetStandard.OAuth2/Model/Accounting/PurchaseOrder.cs
+++ b/Xero.NetStandard.OAuth2/Model/Accounting/PurchaseOrder.cs
@@ -45,7 +45,7 @@ namespace Xero.NetStandard.OAuth2.Model.Accounting
         /// See Purchase Order Status Codes
         /// </summary>
         /// <value>See Purchase Order Status Codes</value>
-        [JsonConverter(typeof(StringEnumConverter))]
+        [JsonConverter(typeof(Client.CustomStringEnumConverter))]
         public enum StatusEnum
         {
             /// <summary>

--- a/Xero.NetStandard.OAuth2/Model/Accounting/QuoteLineAmountTypes.cs
+++ b/Xero.NetStandard.OAuth2/Model/Accounting/QuoteLineAmountTypes.cs
@@ -30,7 +30,7 @@ namespace Xero.NetStandard.OAuth2.Model.Accounting
     /// </summary>
     /// <value>Line amounts are exclusive of tax by default if you don’t specify this element. See Line Amount Types</value>
     
-    [JsonConverter(typeof(StringEnumConverter))]
+    [JsonConverter(typeof(Client.CustomStringEnumConverter))]
     
     public enum QuoteLineAmountTypes
     {

--- a/Xero.NetStandard.OAuth2/Model/Accounting/QuoteStatusCodes.cs
+++ b/Xero.NetStandard.OAuth2/Model/Accounting/QuoteStatusCodes.cs
@@ -30,7 +30,7 @@ namespace Xero.NetStandard.OAuth2.Model.Accounting
     /// </summary>
     /// <value>The status of the quote.</value>
     
-    [JsonConverter(typeof(StringEnumConverter))]
+    [JsonConverter(typeof(Client.CustomStringEnumConverter))]
     
     public enum QuoteStatusCodes
     {

--- a/Xero.NetStandard.OAuth2/Model/Accounting/Receipt.cs
+++ b/Xero.NetStandard.OAuth2/Model/Accounting/Receipt.cs
@@ -40,7 +40,7 @@ namespace Xero.NetStandard.OAuth2.Model.Accounting
         /// Current status of receipt – see status types
         /// </summary>
         /// <value>Current status of receipt – see status types</value>
-        [JsonConverter(typeof(StringEnumConverter))]
+        [JsonConverter(typeof(Client.CustomStringEnumConverter))]
         public enum StatusEnum
         {
             /// <summary>

--- a/Xero.NetStandard.OAuth2/Model/Accounting/RepeatingInvoice.cs
+++ b/Xero.NetStandard.OAuth2/Model/Accounting/RepeatingInvoice.cs
@@ -35,7 +35,7 @@ namespace Xero.NetStandard.OAuth2.Model.Accounting
         /// See Invoice Types
         /// </summary>
         /// <value>See Invoice Types</value>
-        [JsonConverter(typeof(StringEnumConverter))]
+        [JsonConverter(typeof(Client.CustomStringEnumConverter))]
         public enum TypeEnum
         {
             /// <summary>
@@ -72,7 +72,7 @@ namespace Xero.NetStandard.OAuth2.Model.Accounting
         /// One of the following - DRAFT or AUTHORISED – See Invoice Status Codes
         /// </summary>
         /// <value>One of the following - DRAFT or AUTHORISED – See Invoice Status Codes</value>
-        [JsonConverter(typeof(StringEnumConverter))]
+        [JsonConverter(typeof(Client.CustomStringEnumConverter))]
         public enum StatusEnum
         {
             /// <summary>

--- a/Xero.NetStandard.OAuth2/Model/Accounting/Report.cs
+++ b/Xero.NetStandard.OAuth2/Model/Accounting/Report.cs
@@ -35,7 +35,7 @@ namespace Xero.NetStandard.OAuth2.Model.Accounting
         /// See Prepayment Types
         /// </summary>
         /// <value>See Prepayment Types</value>
-        [JsonConverter(typeof(StringEnumConverter))]
+        [JsonConverter(typeof(Client.CustomStringEnumConverter))]
         public enum ReportTypeEnum
         {
             /// <summary>

--- a/Xero.NetStandard.OAuth2/Model/Accounting/RowType.cs
+++ b/Xero.NetStandard.OAuth2/Model/Accounting/RowType.cs
@@ -29,7 +29,7 @@ namespace Xero.NetStandard.OAuth2.Model.Accounting
     /// Defines RowType
     /// </summary>
     
-    [JsonConverter(typeof(StringEnumConverter))]
+    [JsonConverter(typeof(Client.CustomStringEnumConverter))]
     
     public enum RowType
     {

--- a/Xero.NetStandard.OAuth2/Model/Accounting/Schedule.cs
+++ b/Xero.NetStandard.OAuth2/Model/Accounting/Schedule.cs
@@ -35,7 +35,7 @@ namespace Xero.NetStandard.OAuth2.Model.Accounting
         /// One of the following - WEEKLY or MONTHLY
         /// </summary>
         /// <value>One of the following - WEEKLY or MONTHLY</value>
-        [JsonConverter(typeof(StringEnumConverter))]
+        [JsonConverter(typeof(Client.CustomStringEnumConverter))]
         public enum UnitEnum
         {
             /// <summary>
@@ -62,7 +62,7 @@ namespace Xero.NetStandard.OAuth2.Model.Accounting
         /// the payment terms
         /// </summary>
         /// <value>the payment terms</value>
-        [JsonConverter(typeof(StringEnumConverter))]
+        [JsonConverter(typeof(Client.CustomStringEnumConverter))]
         public enum DueDateTypeEnum
         {
             /// <summary>

--- a/Xero.NetStandard.OAuth2/Model/Accounting/TaxRate.cs
+++ b/Xero.NetStandard.OAuth2/Model/Accounting/TaxRate.cs
@@ -35,7 +35,7 @@ namespace Xero.NetStandard.OAuth2.Model.Accounting
         /// See Status Codes
         /// </summary>
         /// <value>See Status Codes</value>
-        [JsonConverter(typeof(StringEnumConverter))]
+        [JsonConverter(typeof(Client.CustomStringEnumConverter))]
         public enum StatusEnum
         {
             /// <summary>
@@ -74,7 +74,7 @@ namespace Xero.NetStandard.OAuth2.Model.Accounting
         /// See ReportTaxTypes
         /// </summary>
         /// <value>See ReportTaxTypes</value>
-        [JsonConverter(typeof(StringEnumConverter))]
+        [JsonConverter(typeof(Client.CustomStringEnumConverter))]
         public enum ReportTaxTypeEnum
         {
             /// <summary>

--- a/Xero.NetStandard.OAuth2/Model/Accounting/TaxType.cs
+++ b/Xero.NetStandard.OAuth2/Model/Accounting/TaxType.cs
@@ -30,7 +30,7 @@ namespace Xero.NetStandard.OAuth2.Model.Accounting
     /// </summary>
     /// <value>See Tax Types – can only be used on update calls</value>
     
-    [JsonConverter(typeof(StringEnumConverter))]
+    [JsonConverter(typeof(Client.CustomStringEnumConverter))]
     
     public enum TaxType
     {

--- a/Xero.NetStandard.OAuth2/Model/Accounting/TimeZone.cs
+++ b/Xero.NetStandard.OAuth2/Model/Accounting/TimeZone.cs
@@ -30,7 +30,7 @@ namespace Xero.NetStandard.OAuth2.Model.Accounting
     /// </summary>
     /// <value>Timezone specifications</value>
     
-    [JsonConverter(typeof(StringEnumConverter))]
+    [JsonConverter(typeof(Client.CustomStringEnumConverter))]
     
     public enum TimeZone
     {

--- a/Xero.NetStandard.OAuth2/Model/Accounting/TrackingCategory.cs
+++ b/Xero.NetStandard.OAuth2/Model/Accounting/TrackingCategory.cs
@@ -35,7 +35,7 @@ namespace Xero.NetStandard.OAuth2.Model.Accounting
         /// The status of a tracking category
         /// </summary>
         /// <value>The status of a tracking category</value>
-        [JsonConverter(typeof(StringEnumConverter))]
+        [JsonConverter(typeof(Client.CustomStringEnumConverter))]
         public enum StatusEnum
         {
             /// <summary>

--- a/Xero.NetStandard.OAuth2/Model/Accounting/TrackingOption.cs
+++ b/Xero.NetStandard.OAuth2/Model/Accounting/TrackingOption.cs
@@ -35,7 +35,7 @@ namespace Xero.NetStandard.OAuth2.Model.Accounting
         /// The status of a tracking option
         /// </summary>
         /// <value>The status of a tracking option</value>
-        [JsonConverter(typeof(StringEnumConverter))]
+        [JsonConverter(typeof(Client.CustomStringEnumConverter))]
         public enum StatusEnum
         {
             /// <summary>

--- a/Xero.NetStandard.OAuth2/Model/Accounting/User.cs
+++ b/Xero.NetStandard.OAuth2/Model/Accounting/User.cs
@@ -35,7 +35,7 @@ namespace Xero.NetStandard.OAuth2.Model.Accounting
         /// User role that defines permissions in Xero and via API (READONLY, INVOICEONLY, STANDARD, FINANCIALADVISER, etc)
         /// </summary>
         /// <value>User role that defines permissions in Xero and via API (READONLY, INVOICEONLY, STANDARD, FINANCIALADVISER, etc)</value>
-        [JsonConverter(typeof(StringEnumConverter))]
+        [JsonConverter(typeof(Client.CustomStringEnumConverter))]
         public enum OrganisationRoleEnum
         {
             /// <summary>

--- a/Xero.NetStandard.OAuth2/Model/Asset/AssetStatus.cs
+++ b/Xero.NetStandard.OAuth2/Model/Asset/AssetStatus.cs
@@ -30,7 +30,7 @@ namespace Xero.NetStandard.OAuth2.Model.Asset
     /// </summary>
     /// <value>See Asset Status Codes.</value>
     
-    [JsonConverter(typeof(StringEnumConverter))]
+    [JsonConverter(typeof(Client.CustomStringEnumConverter))]
     
     public enum AssetStatus
     {

--- a/Xero.NetStandard.OAuth2/Model/Asset/AssetStatusQueryParam.cs
+++ b/Xero.NetStandard.OAuth2/Model/Asset/AssetStatusQueryParam.cs
@@ -30,7 +30,7 @@ namespace Xero.NetStandard.OAuth2.Model.Asset
     /// </summary>
     /// <value>See Asset Status Codes.</value>
     
-    [JsonConverter(typeof(StringEnumConverter))]
+    [JsonConverter(typeof(Client.CustomStringEnumConverter))]
     
     public enum AssetStatusQueryParam
     {

--- a/Xero.NetStandard.OAuth2/Model/Asset/BookDepreciationSetting.cs
+++ b/Xero.NetStandard.OAuth2/Model/Asset/BookDepreciationSetting.cs
@@ -35,7 +35,7 @@ namespace Xero.NetStandard.OAuth2.Model.Asset
         /// The method of depreciation applied to this asset. See Depreciation Methods
         /// </summary>
         /// <value>The method of depreciation applied to this asset. See Depreciation Methods</value>
-        [JsonConverter(typeof(StringEnumConverter))]
+        [JsonConverter(typeof(Client.CustomStringEnumConverter))]
         public enum DepreciationMethodEnum
         {
             /// <summary>
@@ -86,7 +86,7 @@ namespace Xero.NetStandard.OAuth2.Model.Asset
         /// The method of averaging applied to this asset. See Averaging Methods
         /// </summary>
         /// <value>The method of averaging applied to this asset. See Averaging Methods</value>
-        [JsonConverter(typeof(StringEnumConverter))]
+        [JsonConverter(typeof(Client.CustomStringEnumConverter))]
         public enum AveragingMethodEnum
         {
             /// <summary>
@@ -113,7 +113,7 @@ namespace Xero.NetStandard.OAuth2.Model.Asset
         /// See Depreciation Calculation Methods
         /// </summary>
         /// <value>See Depreciation Calculation Methods</value>
-        [JsonConverter(typeof(StringEnumConverter))]
+        [JsonConverter(typeof(Client.CustomStringEnumConverter))]
         public enum DepreciationCalculationMethodEnum
         {
             /// <summary>

--- a/Xero.NetStandard.OAuth2/Model/Bankfeeds/CountryCode.cs
+++ b/Xero.NetStandard.OAuth2/Model/Bankfeeds/CountryCode.cs
@@ -30,7 +30,7 @@ namespace Xero.NetStandard.OAuth2.Model.Bankfeeds
     /// </summary>
     /// <value>ISO-3166 alpha-2 country code, e.g. US, AU This element is required only when the Application supports multi-region. Talk to your Partner Manager to confirm if this is the case.</value>
     
-    [JsonConverter(typeof(StringEnumConverter))]
+    [JsonConverter(typeof(Client.CustomStringEnumConverter))]
     
     public enum CountryCode
     {

--- a/Xero.NetStandard.OAuth2/Model/Bankfeeds/CreditDebitIndicator.cs
+++ b/Xero.NetStandard.OAuth2/Model/Bankfeeds/CreditDebitIndicator.cs
@@ -30,7 +30,7 @@ namespace Xero.NetStandard.OAuth2.Model.Bankfeeds
     /// </summary>
     /// <value>If the statement balances are credit or debit, the CreditDebitIndicator should be specified from the perspective of the Customer.</value>
     
-    [JsonConverter(typeof(StringEnumConverter))]
+    [JsonConverter(typeof(Client.CustomStringEnumConverter))]
     
     public enum CreditDebitIndicator
     {

--- a/Xero.NetStandard.OAuth2/Model/Bankfeeds/CurrencyCode.cs
+++ b/Xero.NetStandard.OAuth2/Model/Bankfeeds/CurrencyCode.cs
@@ -30,7 +30,7 @@ namespace Xero.NetStandard.OAuth2.Model.Bankfeeds
     /// </summary>
     /// <value>3 letter alpha code for the ISO-4217 currency code, e.g. USD, AUD.</value>
     
-    [JsonConverter(typeof(StringEnumConverter))]
+    [JsonConverter(typeof(Client.CustomStringEnumConverter))]
     
     public enum CurrencyCode
     {

--- a/Xero.NetStandard.OAuth2/Model/Bankfeeds/Error.cs
+++ b/Xero.NetStandard.OAuth2/Model/Bankfeeds/Error.cs
@@ -35,7 +35,7 @@ namespace Xero.NetStandard.OAuth2.Model.Bankfeeds
         /// Identifies the type of error.
         /// </summary>
         /// <value>Identifies the type of error.</value>
-        [JsonConverter(typeof(StringEnumConverter))]
+        [JsonConverter(typeof(Client.CustomStringEnumConverter))]
         public enum TypeEnum
         {
             /// <summary>

--- a/Xero.NetStandard.OAuth2/Model/Bankfeeds/FeedConnection.cs
+++ b/Xero.NetStandard.OAuth2/Model/Bankfeeds/FeedConnection.cs
@@ -35,7 +35,7 @@ namespace Xero.NetStandard.OAuth2.Model.Bankfeeds
         /// High level bank account type - BANK CREDITCARD BANK encompasses all bank account types other than credit cards.
         /// </summary>
         /// <value>High level bank account type - BANK CREDITCARD BANK encompasses all bank account types other than credit cards.</value>
-        [JsonConverter(typeof(StringEnumConverter))]
+        [JsonConverter(typeof(Client.CustomStringEnumConverter))]
         public enum AccountTypeEnum
         {
             /// <summary>
@@ -72,7 +72,7 @@ namespace Xero.NetStandard.OAuth2.Model.Bankfeeds
         /// the current status of the feed connection
         /// </summary>
         /// <value>the current status of the feed connection</value>
-        [JsonConverter(typeof(StringEnumConverter))]
+        [JsonConverter(typeof(Client.CustomStringEnumConverter))]
         public enum StatusEnum
         {
             /// <summary>

--- a/Xero.NetStandard.OAuth2/Model/Bankfeeds/Statement.cs
+++ b/Xero.NetStandard.OAuth2/Model/Bankfeeds/Statement.cs
@@ -35,7 +35,7 @@ namespace Xero.NetStandard.OAuth2.Model.Bankfeeds
         /// Current status of statements
         /// </summary>
         /// <value>Current status of statements</value>
-        [JsonConverter(typeof(StringEnumConverter))]
+        [JsonConverter(typeof(Client.CustomStringEnumConverter))]
         public enum StatusEnum
         {
             /// <summary>

--- a/Xero.NetStandard.OAuth2/Model/PayrollAu/AccountType.cs
+++ b/Xero.NetStandard.OAuth2/Model/PayrollAu/AccountType.cs
@@ -30,7 +30,7 @@ namespace Xero.NetStandard.OAuth2.Model.PayrollAu
     /// </summary>
     /// <value>See Account Types</value>
     
-    [JsonConverter(typeof(StringEnumConverter))]
+    [JsonConverter(typeof(Client.CustomStringEnumConverter))]
     
     public enum AccountType
     {

--- a/Xero.NetStandard.OAuth2/Model/PayrollAu/AllowanceType.cs
+++ b/Xero.NetStandard.OAuth2/Model/PayrollAu/AllowanceType.cs
@@ -29,7 +29,7 @@ namespace Xero.NetStandard.OAuth2.Model.PayrollAu
     /// Defines AllowanceType
     /// </summary>
     
-    [JsonConverter(typeof(StringEnumConverter))]
+    [JsonConverter(typeof(Client.CustomStringEnumConverter))]
     
     public enum AllowanceType
     {

--- a/Xero.NetStandard.OAuth2/Model/PayrollAu/CalendarType.cs
+++ b/Xero.NetStandard.OAuth2/Model/PayrollAu/CalendarType.cs
@@ -29,7 +29,7 @@ namespace Xero.NetStandard.OAuth2.Model.PayrollAu
     /// Defines CalendarType
     /// </summary>
     
-    [JsonConverter(typeof(StringEnumConverter))]
+    [JsonConverter(typeof(Client.CustomStringEnumConverter))]
     
     public enum CalendarType
     {

--- a/Xero.NetStandard.OAuth2/Model/PayrollAu/DeductionType.cs
+++ b/Xero.NetStandard.OAuth2/Model/PayrollAu/DeductionType.cs
@@ -34,7 +34,7 @@ namespace Xero.NetStandard.OAuth2.Model.PayrollAu
         /// <summary>
         /// Defines DeductionCategory
         /// </summary>
-        [JsonConverter(typeof(StringEnumConverter))]
+        [JsonConverter(typeof(Client.CustomStringEnumConverter))]
         public enum DeductionCategoryEnum
         {
             /// <summary>

--- a/Xero.NetStandard.OAuth2/Model/PayrollAu/DeductionTypeCalculationType.cs
+++ b/Xero.NetStandard.OAuth2/Model/PayrollAu/DeductionTypeCalculationType.cs
@@ -29,7 +29,7 @@ namespace Xero.NetStandard.OAuth2.Model.PayrollAu
     /// Defines DeductionTypeCalculationType
     /// </summary>
     
-    [JsonConverter(typeof(StringEnumConverter))]
+    [JsonConverter(typeof(Client.CustomStringEnumConverter))]
     
     public enum DeductionTypeCalculationType
     {

--- a/Xero.NetStandard.OAuth2/Model/PayrollAu/EarningsRateCalculationType.cs
+++ b/Xero.NetStandard.OAuth2/Model/PayrollAu/EarningsRateCalculationType.cs
@@ -29,7 +29,7 @@ namespace Xero.NetStandard.OAuth2.Model.PayrollAu
     /// Defines EarningsRateCalculationType
     /// </summary>
     
-    [JsonConverter(typeof(StringEnumConverter))]
+    [JsonConverter(typeof(Client.CustomStringEnumConverter))]
     
     public enum EarningsRateCalculationType
     {

--- a/Xero.NetStandard.OAuth2/Model/PayrollAu/EarningsType.cs
+++ b/Xero.NetStandard.OAuth2/Model/PayrollAu/EarningsType.cs
@@ -29,7 +29,7 @@ namespace Xero.NetStandard.OAuth2.Model.PayrollAu
     /// Defines EarningsType
     /// </summary>
     
-    [JsonConverter(typeof(StringEnumConverter))]
+    [JsonConverter(typeof(Client.CustomStringEnumConverter))]
     
     public enum EarningsType
     {

--- a/Xero.NetStandard.OAuth2/Model/PayrollAu/Employee.cs
+++ b/Xero.NetStandard.OAuth2/Model/PayrollAu/Employee.cs
@@ -35,7 +35,7 @@ namespace Xero.NetStandard.OAuth2.Model.PayrollAu
         /// The employee’s gender. See Employee Gender
         /// </summary>
         /// <value>The employee’s gender. See Employee Gender</value>
-        [JsonConverter(typeof(StringEnumConverter))]
+        [JsonConverter(typeof(Client.CustomStringEnumConverter))]
         public enum GenderEnum
         {
             /// <summary>

--- a/Xero.NetStandard.OAuth2/Model/PayrollAu/EmployeeStatus.cs
+++ b/Xero.NetStandard.OAuth2/Model/PayrollAu/EmployeeStatus.cs
@@ -30,7 +30,7 @@ namespace Xero.NetStandard.OAuth2.Model.PayrollAu
     /// </summary>
     /// <value>Employee Status Types</value>
     
-    [JsonConverter(typeof(StringEnumConverter))]
+    [JsonConverter(typeof(Client.CustomStringEnumConverter))]
     
     public enum EmployeeStatus
     {

--- a/Xero.NetStandard.OAuth2/Model/PayrollAu/EmploymentBasis.cs
+++ b/Xero.NetStandard.OAuth2/Model/PayrollAu/EmploymentBasis.cs
@@ -29,7 +29,7 @@ namespace Xero.NetStandard.OAuth2.Model.PayrollAu
     /// Defines EmploymentBasis
     /// </summary>
     
-    [JsonConverter(typeof(StringEnumConverter))]
+    [JsonConverter(typeof(Client.CustomStringEnumConverter))]
     
     public enum EmploymentBasis
     {

--- a/Xero.NetStandard.OAuth2/Model/PayrollAu/EmploymentTerminationPaymentType.cs
+++ b/Xero.NetStandard.OAuth2/Model/PayrollAu/EmploymentTerminationPaymentType.cs
@@ -29,7 +29,7 @@ namespace Xero.NetStandard.OAuth2.Model.PayrollAu
     /// Defines EmploymentTerminationPaymentType
     /// </summary>
     
-    [JsonConverter(typeof(StringEnumConverter))]
+    [JsonConverter(typeof(Client.CustomStringEnumConverter))]
     
     public enum EmploymentTerminationPaymentType
     {

--- a/Xero.NetStandard.OAuth2/Model/PayrollAu/EntitlementFinalPayPayoutType.cs
+++ b/Xero.NetStandard.OAuth2/Model/PayrollAu/EntitlementFinalPayPayoutType.cs
@@ -29,7 +29,7 @@ namespace Xero.NetStandard.OAuth2.Model.PayrollAu
     /// Defines EntitlementFinalPayPayoutType
     /// </summary>
     
-    [JsonConverter(typeof(StringEnumConverter))]
+    [JsonConverter(typeof(Client.CustomStringEnumConverter))]
     
     public enum EntitlementFinalPayPayoutType
     {

--- a/Xero.NetStandard.OAuth2/Model/PayrollAu/LeaveLineCalculationType.cs
+++ b/Xero.NetStandard.OAuth2/Model/PayrollAu/LeaveLineCalculationType.cs
@@ -30,7 +30,7 @@ namespace Xero.NetStandard.OAuth2.Model.PayrollAu
     /// </summary>
     /// <value>Calculation type for leave line for Opening Balance on Employee</value>
     
-    [JsonConverter(typeof(StringEnumConverter))]
+    [JsonConverter(typeof(Client.CustomStringEnumConverter))]
     
     public enum LeaveLineCalculationType
     {

--- a/Xero.NetStandard.OAuth2/Model/PayrollAu/LeavePeriodStatus.cs
+++ b/Xero.NetStandard.OAuth2/Model/PayrollAu/LeavePeriodStatus.cs
@@ -29,7 +29,7 @@ namespace Xero.NetStandard.OAuth2.Model.PayrollAu
     /// Defines LeavePeriodStatus
     /// </summary>
     
-    [JsonConverter(typeof(StringEnumConverter))]
+    [JsonConverter(typeof(Client.CustomStringEnumConverter))]
     
     public enum LeavePeriodStatus
     {

--- a/Xero.NetStandard.OAuth2/Model/PayrollAu/LeaveTypeContributionType.cs
+++ b/Xero.NetStandard.OAuth2/Model/PayrollAu/LeaveTypeContributionType.cs
@@ -29,7 +29,7 @@ namespace Xero.NetStandard.OAuth2.Model.PayrollAu
     /// Defines LeaveTypeContributionType
     /// </summary>
     
-    [JsonConverter(typeof(StringEnumConverter))]
+    [JsonConverter(typeof(Client.CustomStringEnumConverter))]
     
     public enum LeaveTypeContributionType
     {

--- a/Xero.NetStandard.OAuth2/Model/PayrollAu/ManualTaxType.cs
+++ b/Xero.NetStandard.OAuth2/Model/PayrollAu/ManualTaxType.cs
@@ -29,7 +29,7 @@ namespace Xero.NetStandard.OAuth2.Model.PayrollAu
     /// Defines ManualTaxType
     /// </summary>
     
-    [JsonConverter(typeof(StringEnumConverter))]
+    [JsonConverter(typeof(Client.CustomStringEnumConverter))]
     
     public enum ManualTaxType
     {

--- a/Xero.NetStandard.OAuth2/Model/PayrollAu/PayRunStatus.cs
+++ b/Xero.NetStandard.OAuth2/Model/PayrollAu/PayRunStatus.cs
@@ -29,7 +29,7 @@ namespace Xero.NetStandard.OAuth2.Model.PayrollAu
     /// Defines PayRunStatus
     /// </summary>
     
-    [JsonConverter(typeof(StringEnumConverter))]
+    [JsonConverter(typeof(Client.CustomStringEnumConverter))]
     
     public enum PayRunStatus
     {

--- a/Xero.NetStandard.OAuth2/Model/PayrollAu/PaymentFrequencyType.cs
+++ b/Xero.NetStandard.OAuth2/Model/PayrollAu/PaymentFrequencyType.cs
@@ -29,7 +29,7 @@ namespace Xero.NetStandard.OAuth2.Model.PayrollAu
     /// Defines PaymentFrequencyType
     /// </summary>
     
-    [JsonConverter(typeof(StringEnumConverter))]
+    [JsonConverter(typeof(Client.CustomStringEnumConverter))]
     
     public enum PaymentFrequencyType
     {

--- a/Xero.NetStandard.OAuth2/Model/PayrollAu/RateType.cs
+++ b/Xero.NetStandard.OAuth2/Model/PayrollAu/RateType.cs
@@ -29,7 +29,7 @@ namespace Xero.NetStandard.OAuth2.Model.PayrollAu
     /// Defines RateType
     /// </summary>
     
-    [JsonConverter(typeof(StringEnumConverter))]
+    [JsonConverter(typeof(Client.CustomStringEnumConverter))]
     
     public enum RateType
     {

--- a/Xero.NetStandard.OAuth2/Model/PayrollAu/ResidencyStatus.cs
+++ b/Xero.NetStandard.OAuth2/Model/PayrollAu/ResidencyStatus.cs
@@ -29,7 +29,7 @@ namespace Xero.NetStandard.OAuth2.Model.PayrollAu
     /// Defines ResidencyStatus
     /// </summary>
     
-    [JsonConverter(typeof(StringEnumConverter))]
+    [JsonConverter(typeof(Client.CustomStringEnumConverter))]
     
     public enum ResidencyStatus
     {

--- a/Xero.NetStandard.OAuth2/Model/PayrollAu/State.cs
+++ b/Xero.NetStandard.OAuth2/Model/PayrollAu/State.cs
@@ -30,7 +30,7 @@ namespace Xero.NetStandard.OAuth2.Model.PayrollAu
     /// </summary>
     /// <value>State abbreviation for employee home address</value>
     
-    [JsonConverter(typeof(StringEnumConverter))]
+    [JsonConverter(typeof(Client.CustomStringEnumConverter))]
     
     public enum State
     {

--- a/Xero.NetStandard.OAuth2/Model/PayrollAu/SuperFundType.cs
+++ b/Xero.NetStandard.OAuth2/Model/PayrollAu/SuperFundType.cs
@@ -29,7 +29,7 @@ namespace Xero.NetStandard.OAuth2.Model.PayrollAu
     /// Defines SuperFundType
     /// </summary>
     
-    [JsonConverter(typeof(StringEnumConverter))]
+    [JsonConverter(typeof(Client.CustomStringEnumConverter))]
     
     public enum SuperFundType
     {

--- a/Xero.NetStandard.OAuth2/Model/PayrollAu/SuperannuationCalculationType.cs
+++ b/Xero.NetStandard.OAuth2/Model/PayrollAu/SuperannuationCalculationType.cs
@@ -29,7 +29,7 @@ namespace Xero.NetStandard.OAuth2.Model.PayrollAu
     /// Defines SuperannuationCalculationType
     /// </summary>
     
-    [JsonConverter(typeof(StringEnumConverter))]
+    [JsonConverter(typeof(Client.CustomStringEnumConverter))]
     
     public enum SuperannuationCalculationType
     {

--- a/Xero.NetStandard.OAuth2/Model/PayrollAu/SuperannuationContributionType.cs
+++ b/Xero.NetStandard.OAuth2/Model/PayrollAu/SuperannuationContributionType.cs
@@ -29,7 +29,7 @@ namespace Xero.NetStandard.OAuth2.Model.PayrollAu
     /// Defines SuperannuationContributionType
     /// </summary>
     
-    [JsonConverter(typeof(StringEnumConverter))]
+    [JsonConverter(typeof(Client.CustomStringEnumConverter))]
     
     public enum SuperannuationContributionType
     {

--- a/Xero.NetStandard.OAuth2/Model/PayrollAu/TFNExemptionType.cs
+++ b/Xero.NetStandard.OAuth2/Model/PayrollAu/TFNExemptionType.cs
@@ -29,7 +29,7 @@ namespace Xero.NetStandard.OAuth2.Model.PayrollAu
     /// Defines TFNExemptionType
     /// </summary>
     
-    [JsonConverter(typeof(StringEnumConverter))]
+    [JsonConverter(typeof(Client.CustomStringEnumConverter))]
     
     public enum TFNExemptionType
     {

--- a/Xero.NetStandard.OAuth2/Model/PayrollAu/TimesheetStatus.cs
+++ b/Xero.NetStandard.OAuth2/Model/PayrollAu/TimesheetStatus.cs
@@ -29,7 +29,7 @@ namespace Xero.NetStandard.OAuth2.Model.PayrollAu
     /// Defines TimesheetStatus
     /// </summary>
     
-    [JsonConverter(typeof(StringEnumConverter))]
+    [JsonConverter(typeof(Client.CustomStringEnumConverter))]
     
     public enum TimesheetStatus
     {

--- a/Xero.NetStandard.OAuth2/Model/PayrollNz/Account.cs
+++ b/Xero.NetStandard.OAuth2/Model/PayrollNz/Account.cs
@@ -35,7 +35,7 @@ namespace Xero.NetStandard.OAuth2.Model.PayrollNz
         /// The assigned AccountType
         /// </summary>
         /// <value>The assigned AccountType</value>
-        [JsonConverter(typeof(StringEnumConverter))]
+        [JsonConverter(typeof(Client.CustomStringEnumConverter))]
         public enum TypeEnum
         {
             /// <summary>

--- a/Xero.NetStandard.OAuth2/Model/PayrollNz/BankAccount.cs
+++ b/Xero.NetStandard.OAuth2/Model/PayrollNz/BankAccount.cs
@@ -35,7 +35,7 @@ namespace Xero.NetStandard.OAuth2.Model.PayrollNz
         /// Calculation type for the transaction can be &#39;Fixed Amount&#39; or &#39;Balance&#39;
         /// </summary>
         /// <value>Calculation type for the transaction can be &#39;Fixed Amount&#39; or &#39;Balance&#39;</value>
-        [JsonConverter(typeof(StringEnumConverter))]
+        [JsonConverter(typeof(Client.CustomStringEnumConverter))]
         public enum CalculationTypeEnum
         {
             /// <summary>

--- a/Xero.NetStandard.OAuth2/Model/PayrollNz/Benefit.cs
+++ b/Xero.NetStandard.OAuth2/Model/PayrollNz/Benefit.cs
@@ -35,7 +35,7 @@ namespace Xero.NetStandard.OAuth2.Model.PayrollNz
         /// Superannuations Category type
         /// </summary>
         /// <value>Superannuations Category type</value>
-        [JsonConverter(typeof(StringEnumConverter))]
+        [JsonConverter(typeof(Client.CustomStringEnumConverter))]
         public enum CategoryEnum
         {
             /// <summary>
@@ -68,7 +68,7 @@ namespace Xero.NetStandard.OAuth2.Model.PayrollNz
         /// Calculation Type of the superannuation either FixedAmount or PercentageOfTaxableEarnings
         /// </summary>
         /// <value>Calculation Type of the superannuation either FixedAmount or PercentageOfTaxableEarnings</value>
-        [JsonConverter(typeof(StringEnumConverter))]
+        [JsonConverter(typeof(Client.CustomStringEnumConverter))]
         public enum CalculationTypeNZEnum
         {
             /// <summary>

--- a/Xero.NetStandard.OAuth2/Model/PayrollNz/CalendarType.cs
+++ b/Xero.NetStandard.OAuth2/Model/PayrollNz/CalendarType.cs
@@ -30,7 +30,7 @@ namespace Xero.NetStandard.OAuth2.Model.PayrollNz
     /// </summary>
     /// <value>Calendar type of the pay run</value>
     
-    [JsonConverter(typeof(StringEnumConverter))]
+    [JsonConverter(typeof(Client.CustomStringEnumConverter))]
     
     public enum CalendarType
     {

--- a/Xero.NetStandard.OAuth2/Model/PayrollNz/Deduction.cs
+++ b/Xero.NetStandard.OAuth2/Model/PayrollNz/Deduction.cs
@@ -35,7 +35,7 @@ namespace Xero.NetStandard.OAuth2.Model.PayrollNz
         /// Deduction Category type
         /// </summary>
         /// <value>Deduction Category type</value>
-        [JsonConverter(typeof(StringEnumConverter))]
+        [JsonConverter(typeof(Client.CustomStringEnumConverter))]
         public enum DeductionCategoryEnum
         {
             /// <summary>

--- a/Xero.NetStandard.OAuth2/Model/PayrollNz/EarningsRate.cs
+++ b/Xero.NetStandard.OAuth2/Model/PayrollNz/EarningsRate.cs
@@ -35,7 +35,7 @@ namespace Xero.NetStandard.OAuth2.Model.PayrollNz
         /// Indicates how an employee will be paid when taking this type of earning
         /// </summary>
         /// <value>Indicates how an employee will be paid when taking this type of earning</value>
-        [JsonConverter(typeof(StringEnumConverter))]
+        [JsonConverter(typeof(Client.CustomStringEnumConverter))]
         public enum EarningsTypeEnum
         {
             /// <summary>
@@ -140,7 +140,7 @@ namespace Xero.NetStandard.OAuth2.Model.PayrollNz
         /// Indicates the type of the earning rate
         /// </summary>
         /// <value>Indicates the type of the earning rate</value>
-        [JsonConverter(typeof(StringEnumConverter))]
+        [JsonConverter(typeof(Client.CustomStringEnumConverter))]
         public enum RateTypeEnum
         {
             /// <summary>

--- a/Xero.NetStandard.OAuth2/Model/PayrollNz/Employee.cs
+++ b/Xero.NetStandard.OAuth2/Model/PayrollNz/Employee.cs
@@ -35,7 +35,7 @@ namespace Xero.NetStandard.OAuth2.Model.PayrollNz
         /// The employee’s gender
         /// </summary>
         /// <value>The employee’s gender</value>
-        [JsonConverter(typeof(StringEnumConverter))]
+        [JsonConverter(typeof(Client.CustomStringEnumConverter))]
         public enum GenderEnum
         {
             /// <summary>

--- a/Xero.NetStandard.OAuth2/Model/PayrollNz/EmployeeLeaveType.cs
+++ b/Xero.NetStandard.OAuth2/Model/PayrollNz/EmployeeLeaveType.cs
@@ -35,7 +35,7 @@ namespace Xero.NetStandard.OAuth2.Model.PayrollNz
         /// The schedule of accrual
         /// </summary>
         /// <value>The schedule of accrual</value>
-        [JsonConverter(typeof(StringEnumConverter))]
+        [JsonConverter(typeof(Client.CustomStringEnumConverter))]
         public enum ScheduleOfAccrualEnum
         {
             /// <summary>

--- a/Xero.NetStandard.OAuth2/Model/PayrollNz/EmployeeStatutoryLeaveBalance.cs
+++ b/Xero.NetStandard.OAuth2/Model/PayrollNz/EmployeeStatutoryLeaveBalance.cs
@@ -35,7 +35,7 @@ namespace Xero.NetStandard.OAuth2.Model.PayrollNz
         /// The type of statutory leave
         /// </summary>
         /// <value>The type of statutory leave</value>
-        [JsonConverter(typeof(StringEnumConverter))]
+        [JsonConverter(typeof(Client.CustomStringEnumConverter))]
         public enum LeaveTypeEnum
         {
             /// <summary>
@@ -80,7 +80,7 @@ namespace Xero.NetStandard.OAuth2.Model.PayrollNz
         /// The units will be \&quot;Hours\&quot;
         /// </summary>
         /// <value>The units will be \&quot;Hours\&quot;</value>
-        [JsonConverter(typeof(StringEnumConverter))]
+        [JsonConverter(typeof(Client.CustomStringEnumConverter))]
         public enum UnitsEnum
         {
             /// <summary>

--- a/Xero.NetStandard.OAuth2/Model/PayrollNz/EmployeeStatutoryLeaveSummary.cs
+++ b/Xero.NetStandard.OAuth2/Model/PayrollNz/EmployeeStatutoryLeaveSummary.cs
@@ -35,7 +35,7 @@ namespace Xero.NetStandard.OAuth2.Model.PayrollNz
         /// The category of statutory leave
         /// </summary>
         /// <value>The category of statutory leave</value>
-        [JsonConverter(typeof(StringEnumConverter))]
+        [JsonConverter(typeof(Client.CustomStringEnumConverter))]
         public enum TypeEnum
         {
             /// <summary>
@@ -80,7 +80,7 @@ namespace Xero.NetStandard.OAuth2.Model.PayrollNz
         /// The status of the leave
         /// </summary>
         /// <value>The status of the leave</value>
-        [JsonConverter(typeof(StringEnumConverter))]
+        [JsonConverter(typeof(Client.CustomStringEnumConverter))]
         public enum StatusEnum
         {
             /// <summary>

--- a/Xero.NetStandard.OAuth2/Model/PayrollNz/EmployeeStatutorySickLeave.cs
+++ b/Xero.NetStandard.OAuth2/Model/PayrollNz/EmployeeStatutorySickLeave.cs
@@ -34,7 +34,7 @@ namespace Xero.NetStandard.OAuth2.Model.PayrollNz
         /// <summary>
         /// Defines EntitlementFailureReasons
         /// </summary>
-        [JsonConverter(typeof(StringEnumConverter))]
+        [JsonConverter(typeof(Client.CustomStringEnumConverter))]
         public enum EntitlementFailureReasonsEnum
         {
             /// <summary>

--- a/Xero.NetStandard.OAuth2/Model/PayrollNz/EmployeeTax.cs
+++ b/Xero.NetStandard.OAuth2/Model/PayrollNz/EmployeeTax.cs
@@ -40,7 +40,7 @@ namespace Xero.NetStandard.OAuth2.Model.PayrollNz
         /// Contribution Option which can be &#39;MakeContributions&#39; &#39;OptOut&#39;, &#39;OnAContributionsHoliday&#39;, &#39;OnASavingsSuspension&#39;, &#39;NotCurrentlyAKiwiSaverMember&#39; for employees without a KiwiSaver membership
         /// </summary>
         /// <value>Contribution Option which can be &#39;MakeContributions&#39; &#39;OptOut&#39;, &#39;OnAContributionsHoliday&#39;, &#39;OnASavingsSuspension&#39;, &#39;NotCurrentlyAKiwiSaverMember&#39; for employees without a KiwiSaver membership</value>
-        [JsonConverter(typeof(StringEnumConverter))]
+        [JsonConverter(typeof(Client.CustomStringEnumConverter))]
         public enum KiwiSaverContributionsEnum
         {
             /// <summary>

--- a/Xero.NetStandard.OAuth2/Model/PayrollNz/LeavePeriod.cs
+++ b/Xero.NetStandard.OAuth2/Model/PayrollNz/LeavePeriod.cs
@@ -35,7 +35,7 @@ namespace Xero.NetStandard.OAuth2.Model.PayrollNz
         /// Period Status
         /// </summary>
         /// <value>Period Status</value>
-        [JsonConverter(typeof(StringEnumConverter))]
+        [JsonConverter(typeof(Client.CustomStringEnumConverter))]
         public enum PeriodStatusEnum
         {
             /// <summary>

--- a/Xero.NetStandard.OAuth2/Model/PayrollNz/PayRun.cs
+++ b/Xero.NetStandard.OAuth2/Model/PayrollNz/PayRun.cs
@@ -35,7 +35,7 @@ namespace Xero.NetStandard.OAuth2.Model.PayrollNz
         /// Pay run status
         /// </summary>
         /// <value>Pay run status</value>
-        [JsonConverter(typeof(StringEnumConverter))]
+        [JsonConverter(typeof(Client.CustomStringEnumConverter))]
         public enum PayRunStatusEnum
         {
             /// <summary>
@@ -62,7 +62,7 @@ namespace Xero.NetStandard.OAuth2.Model.PayrollNz
         /// Pay run type
         /// </summary>
         /// <value>Pay run type</value>
-        [JsonConverter(typeof(StringEnumConverter))]
+        [JsonConverter(typeof(Client.CustomStringEnumConverter))]
         public enum PayRunTypeEnum
         {
             /// <summary>

--- a/Xero.NetStandard.OAuth2/Model/PayrollNz/PaySlip.cs
+++ b/Xero.NetStandard.OAuth2/Model/PayrollNz/PaySlip.cs
@@ -35,7 +35,7 @@ namespace Xero.NetStandard.OAuth2.Model.PayrollNz
         /// The payment method code
         /// </summary>
         /// <value>The payment method code</value>
-        [JsonConverter(typeof(StringEnumConverter))]
+        [JsonConverter(typeof(Client.CustomStringEnumConverter))]
         public enum PaymentMethodEnum
         {
             /// <summary>

--- a/Xero.NetStandard.OAuth2/Model/PayrollNz/PaymentMethod.cs
+++ b/Xero.NetStandard.OAuth2/Model/PayrollNz/PaymentMethod.cs
@@ -35,7 +35,7 @@ namespace Xero.NetStandard.OAuth2.Model.PayrollNz
         /// The payment method code
         /// </summary>
         /// <value>The payment method code</value>
-        [JsonConverter(typeof(StringEnumConverter))]
+        [JsonConverter(typeof(Client.CustomStringEnumConverter))]
         public enum PaymentMethodEnum
         {
             /// <summary>

--- a/Xero.NetStandard.OAuth2/Model/PayrollNz/Reimbursement.cs
+++ b/Xero.NetStandard.OAuth2/Model/PayrollNz/Reimbursement.cs
@@ -35,7 +35,7 @@ namespace Xero.NetStandard.OAuth2.Model.PayrollNz
         /// See Reimbursement Categories
         /// </summary>
         /// <value>See Reimbursement Categories</value>
-        [JsonConverter(typeof(StringEnumConverter))]
+        [JsonConverter(typeof(Client.CustomStringEnumConverter))]
         public enum ReimbursementCategoryEnum
         {
             /// <summary>
@@ -68,7 +68,7 @@ namespace Xero.NetStandard.OAuth2.Model.PayrollNz
         /// See Calculation Types
         /// </summary>
         /// <value>See Calculation Types</value>
-        [JsonConverter(typeof(StringEnumConverter))]
+        [JsonConverter(typeof(Client.CustomStringEnumConverter))]
         public enum CalculationTypeEnum
         {
             /// <summary>
@@ -101,7 +101,7 @@ namespace Xero.NetStandard.OAuth2.Model.PayrollNz
         /// Optional Type Of Units. Applicable when calculation type is Rate Per Unit
         /// </summary>
         /// <value>Optional Type Of Units. Applicable when calculation type is Rate Per Unit</value>
-        [JsonConverter(typeof(StringEnumConverter))]
+        [JsonConverter(typeof(Client.CustomStringEnumConverter))]
         public enum StandardTypeOfUnitsEnum
         {
             /// <summary>

--- a/Xero.NetStandard.OAuth2/Model/PayrollNz/SalaryAndWage.cs
+++ b/Xero.NetStandard.OAuth2/Model/PayrollNz/SalaryAndWage.cs
@@ -35,7 +35,7 @@ namespace Xero.NetStandard.OAuth2.Model.PayrollNz
         /// The current status of the corresponding salary and wages
         /// </summary>
         /// <value>The current status of the corresponding salary and wages</value>
-        [JsonConverter(typeof(StringEnumConverter))]
+        [JsonConverter(typeof(Client.CustomStringEnumConverter))]
         public enum StatusEnum
         {
             /// <summary>
@@ -62,7 +62,7 @@ namespace Xero.NetStandard.OAuth2.Model.PayrollNz
         /// The type of the payment of the corresponding salary and wages
         /// </summary>
         /// <value>The type of the payment of the corresponding salary and wages</value>
-        [JsonConverter(typeof(StringEnumConverter))]
+        [JsonConverter(typeof(Client.CustomStringEnumConverter))]
         public enum PaymentTypeEnum
         {
             /// <summary>

--- a/Xero.NetStandard.OAuth2/Model/PayrollNz/StatutoryDeductionCategory.cs
+++ b/Xero.NetStandard.OAuth2/Model/PayrollNz/StatutoryDeductionCategory.cs
@@ -30,7 +30,7 @@ namespace Xero.NetStandard.OAuth2.Model.PayrollNz
     /// </summary>
     /// <value>Statutory Deduction Category</value>
     
-    [JsonConverter(typeof(StringEnumConverter))]
+    [JsonConverter(typeof(Client.CustomStringEnumConverter))]
     
     public enum StatutoryDeductionCategory
     {

--- a/Xero.NetStandard.OAuth2/Model/PayrollNz/TaxCode.cs
+++ b/Xero.NetStandard.OAuth2/Model/PayrollNz/TaxCode.cs
@@ -30,7 +30,7 @@ namespace Xero.NetStandard.OAuth2.Model.PayrollNz
     /// </summary>
     /// <value>Tax codes used for employee tax</value>
     
-    [JsonConverter(typeof(StringEnumConverter))]
+    [JsonConverter(typeof(Client.CustomStringEnumConverter))]
     
     public enum TaxCode
     {

--- a/Xero.NetStandard.OAuth2/Model/PayrollNz/TaxSettings.cs
+++ b/Xero.NetStandard.OAuth2/Model/PayrollNz/TaxSettings.cs
@@ -35,7 +35,7 @@ namespace Xero.NetStandard.OAuth2.Model.PayrollNz
         /// The type of period (\&quot;weeks\&quot; or \&quot;months\&quot;)
         /// </summary>
         /// <value>The type of period (\&quot;weeks\&quot; or \&quot;months\&quot;)</value>
-        [JsonConverter(typeof(StringEnumConverter))]
+        [JsonConverter(typeof(Client.CustomStringEnumConverter))]
         public enum PeriodTypeEnum
         {
             /// <summary>

--- a/Xero.NetStandard.OAuth2/Model/PayrollNz/Timesheet.cs
+++ b/Xero.NetStandard.OAuth2/Model/PayrollNz/Timesheet.cs
@@ -35,7 +35,7 @@ namespace Xero.NetStandard.OAuth2.Model.PayrollNz
         /// Status of the timesheet
         /// </summary>
         /// <value>Status of the timesheet</value>
-        [JsonConverter(typeof(StringEnumConverter))]
+        [JsonConverter(typeof(Client.CustomStringEnumConverter))]
         public enum StatusEnum
         {
             /// <summary>

--- a/Xero.NetStandard.OAuth2/Model/PayrollUk/Account.cs
+++ b/Xero.NetStandard.OAuth2/Model/PayrollUk/Account.cs
@@ -35,7 +35,7 @@ namespace Xero.NetStandard.OAuth2.Model.PayrollUk
         /// The assigned AccountType
         /// </summary>
         /// <value>The assigned AccountType</value>
-        [JsonConverter(typeof(StringEnumConverter))]
+        [JsonConverter(typeof(Client.CustomStringEnumConverter))]
         public enum TypeEnum
         {
             /// <summary>

--- a/Xero.NetStandard.OAuth2/Model/PayrollUk/Benefit.cs
+++ b/Xero.NetStandard.OAuth2/Model/PayrollUk/Benefit.cs
@@ -35,7 +35,7 @@ namespace Xero.NetStandard.OAuth2.Model.PayrollUk
         /// Category type of the employer pension
         /// </summary>
         /// <value>Category type of the employer pension</value>
-        [JsonConverter(typeof(StringEnumConverter))]
+        [JsonConverter(typeof(Client.CustomStringEnumConverter))]
         public enum CategoryEnum
         {
             /// <summary>
@@ -62,7 +62,7 @@ namespace Xero.NetStandard.OAuth2.Model.PayrollUk
         /// Calculation Type of the employer pension (FixedAmount or PercentageOfGross).
         /// </summary>
         /// <value>Calculation Type of the employer pension (FixedAmount or PercentageOfGross).</value>
-        [JsonConverter(typeof(StringEnumConverter))]
+        [JsonConverter(typeof(Client.CustomStringEnumConverter))]
         public enum CalculationTypeEnum
         {
             /// <summary>

--- a/Xero.NetStandard.OAuth2/Model/PayrollUk/Deduction.cs
+++ b/Xero.NetStandard.OAuth2/Model/PayrollUk/Deduction.cs
@@ -35,7 +35,7 @@ namespace Xero.NetStandard.OAuth2.Model.PayrollUk
         /// Deduction Category type
         /// </summary>
         /// <value>Deduction Category type</value>
-        [JsonConverter(typeof(StringEnumConverter))]
+        [JsonConverter(typeof(Client.CustomStringEnumConverter))]
         public enum DeductionCategoryEnum
         {
             /// <summary>
@@ -110,7 +110,7 @@ namespace Xero.NetStandard.OAuth2.Model.PayrollUk
         /// determine the calculation type whether fixed amount or percentage of gross
         /// </summary>
         /// <value>determine the calculation type whether fixed amount or percentage of gross</value>
-        [JsonConverter(typeof(StringEnumConverter))]
+        [JsonConverter(typeof(Client.CustomStringEnumConverter))]
         public enum CalculationTypeEnum
         {
             /// <summary>

--- a/Xero.NetStandard.OAuth2/Model/PayrollUk/EarningsRate.cs
+++ b/Xero.NetStandard.OAuth2/Model/PayrollUk/EarningsRate.cs
@@ -35,7 +35,7 @@ namespace Xero.NetStandard.OAuth2.Model.PayrollUk
         /// Indicates how an employee will be paid when taking this type of earning
         /// </summary>
         /// <value>Indicates how an employee will be paid when taking this type of earning</value>
-        [JsonConverter(typeof(StringEnumConverter))]
+        [JsonConverter(typeof(Client.CustomStringEnumConverter))]
         public enum EarningsTypeEnum
         {
             /// <summary>
@@ -140,7 +140,7 @@ namespace Xero.NetStandard.OAuth2.Model.PayrollUk
         /// Indicates the type of the earning rate
         /// </summary>
         /// <value>Indicates the type of the earning rate</value>
-        [JsonConverter(typeof(StringEnumConverter))]
+        [JsonConverter(typeof(Client.CustomStringEnumConverter))]
         public enum RateTypeEnum
         {
             /// <summary>

--- a/Xero.NetStandard.OAuth2/Model/PayrollUk/Employee.cs
+++ b/Xero.NetStandard.OAuth2/Model/PayrollUk/Employee.cs
@@ -35,7 +35,7 @@ namespace Xero.NetStandard.OAuth2.Model.PayrollUk
         /// The employee’s gender
         /// </summary>
         /// <value>The employee’s gender</value>
-        [JsonConverter(typeof(StringEnumConverter))]
+        [JsonConverter(typeof(Client.CustomStringEnumConverter))]
         public enum GenderEnum
         {
             /// <summary>

--- a/Xero.NetStandard.OAuth2/Model/PayrollUk/EmployeeLeaveType.cs
+++ b/Xero.NetStandard.OAuth2/Model/PayrollUk/EmployeeLeaveType.cs
@@ -35,7 +35,7 @@ namespace Xero.NetStandard.OAuth2.Model.PayrollUk
         /// The schedule of accrual
         /// </summary>
         /// <value>The schedule of accrual</value>
-        [JsonConverter(typeof(StringEnumConverter))]
+        [JsonConverter(typeof(Client.CustomStringEnumConverter))]
         public enum ScheduleOfAccrualEnum
         {
             /// <summary>

--- a/Xero.NetStandard.OAuth2/Model/PayrollUk/EmployeeStatutoryLeaveBalance.cs
+++ b/Xero.NetStandard.OAuth2/Model/PayrollUk/EmployeeStatutoryLeaveBalance.cs
@@ -35,7 +35,7 @@ namespace Xero.NetStandard.OAuth2.Model.PayrollUk
         /// The type of statutory leave
         /// </summary>
         /// <value>The type of statutory leave</value>
-        [JsonConverter(typeof(StringEnumConverter))]
+        [JsonConverter(typeof(Client.CustomStringEnumConverter))]
         public enum LeaveTypeEnum
         {
             /// <summary>
@@ -80,7 +80,7 @@ namespace Xero.NetStandard.OAuth2.Model.PayrollUk
         /// The units will be \&quot;Hours\&quot;
         /// </summary>
         /// <value>The units will be \&quot;Hours\&quot;</value>
-        [JsonConverter(typeof(StringEnumConverter))]
+        [JsonConverter(typeof(Client.CustomStringEnumConverter))]
         public enum UnitsEnum
         {
             /// <summary>

--- a/Xero.NetStandard.OAuth2/Model/PayrollUk/EmployeeStatutoryLeaveSummary.cs
+++ b/Xero.NetStandard.OAuth2/Model/PayrollUk/EmployeeStatutoryLeaveSummary.cs
@@ -35,7 +35,7 @@ namespace Xero.NetStandard.OAuth2.Model.PayrollUk
         /// The category of statutory leave
         /// </summary>
         /// <value>The category of statutory leave</value>
-        [JsonConverter(typeof(StringEnumConverter))]
+        [JsonConverter(typeof(Client.CustomStringEnumConverter))]
         public enum TypeEnum
         {
             /// <summary>
@@ -80,7 +80,7 @@ namespace Xero.NetStandard.OAuth2.Model.PayrollUk
         /// The status of the leave
         /// </summary>
         /// <value>The status of the leave</value>
-        [JsonConverter(typeof(StringEnumConverter))]
+        [JsonConverter(typeof(Client.CustomStringEnumConverter))]
         public enum StatusEnum
         {
             /// <summary>

--- a/Xero.NetStandard.OAuth2/Model/PayrollUk/EmployeeStatutorySickLeave.cs
+++ b/Xero.NetStandard.OAuth2/Model/PayrollUk/EmployeeStatutorySickLeave.cs
@@ -34,7 +34,7 @@ namespace Xero.NetStandard.OAuth2.Model.PayrollUk
         /// <summary>
         /// Defines EntitlementFailureReasons
         /// </summary>
-        [JsonConverter(typeof(StringEnumConverter))]
+        [JsonConverter(typeof(Client.CustomStringEnumConverter))]
         public enum EntitlementFailureReasonsEnum
         {
             /// <summary>

--- a/Xero.NetStandard.OAuth2/Model/PayrollUk/Employment.cs
+++ b/Xero.NetStandard.OAuth2/Model/PayrollUk/Employment.cs
@@ -35,7 +35,7 @@ namespace Xero.NetStandard.OAuth2.Model.PayrollUk
         /// The NI Category of the employee
         /// </summary>
         /// <value>The NI Category of the employee</value>
-        [JsonConverter(typeof(StringEnumConverter))]
+        [JsonConverter(typeof(Client.CustomStringEnumConverter))]
         public enum NiCategoryEnum
         {
             /// <summary>

--- a/Xero.NetStandard.OAuth2/Model/PayrollUk/LeavePeriod.cs
+++ b/Xero.NetStandard.OAuth2/Model/PayrollUk/LeavePeriod.cs
@@ -35,7 +35,7 @@ namespace Xero.NetStandard.OAuth2.Model.PayrollUk
         /// Period Status
         /// </summary>
         /// <value>Period Status</value>
-        [JsonConverter(typeof(StringEnumConverter))]
+        [JsonConverter(typeof(Client.CustomStringEnumConverter))]
         public enum PeriodStatusEnum
         {
             /// <summary>

--- a/Xero.NetStandard.OAuth2/Model/PayrollUk/PayRun.cs
+++ b/Xero.NetStandard.OAuth2/Model/PayrollUk/PayRun.cs
@@ -35,7 +35,7 @@ namespace Xero.NetStandard.OAuth2.Model.PayrollUk
         /// Pay run status
         /// </summary>
         /// <value>Pay run status</value>
-        [JsonConverter(typeof(StringEnumConverter))]
+        [JsonConverter(typeof(Client.CustomStringEnumConverter))]
         public enum PayRunStatusEnum
         {
             /// <summary>
@@ -62,7 +62,7 @@ namespace Xero.NetStandard.OAuth2.Model.PayrollUk
         /// Pay run type
         /// </summary>
         /// <value>Pay run type</value>
-        [JsonConverter(typeof(StringEnumConverter))]
+        [JsonConverter(typeof(Client.CustomStringEnumConverter))]
         public enum PayRunTypeEnum
         {
             /// <summary>
@@ -95,7 +95,7 @@ namespace Xero.NetStandard.OAuth2.Model.PayrollUk
         /// Calendar type of the pay run
         /// </summary>
         /// <value>Calendar type of the pay run</value>
-        [JsonConverter(typeof(StringEnumConverter))]
+        [JsonConverter(typeof(Client.CustomStringEnumConverter))]
         public enum CalendarTypeEnum
         {
             /// <summary>

--- a/Xero.NetStandard.OAuth2/Model/PayrollUk/PayRunCalendar.cs
+++ b/Xero.NetStandard.OAuth2/Model/PayrollUk/PayRunCalendar.cs
@@ -35,7 +35,7 @@ namespace Xero.NetStandard.OAuth2.Model.PayrollUk
         /// Type of the calendar
         /// </summary>
         /// <value>Type of the calendar</value>
-        [JsonConverter(typeof(StringEnumConverter))]
+        [JsonConverter(typeof(Client.CustomStringEnumConverter))]
         public enum CalendarTypeEnum
         {
             /// <summary>

--- a/Xero.NetStandard.OAuth2/Model/PayrollUk/PaymentMethod.cs
+++ b/Xero.NetStandard.OAuth2/Model/PayrollUk/PaymentMethod.cs
@@ -35,7 +35,7 @@ namespace Xero.NetStandard.OAuth2.Model.PayrollUk
         /// The payment method code
         /// </summary>
         /// <value>The payment method code</value>
-        [JsonConverter(typeof(StringEnumConverter))]
+        [JsonConverter(typeof(Client.CustomStringEnumConverter))]
         public enum PaymentMethodEnum
         {
             /// <summary>

--- a/Xero.NetStandard.OAuth2/Model/PayrollUk/Payslip.cs
+++ b/Xero.NetStandard.OAuth2/Model/PayrollUk/Payslip.cs
@@ -35,7 +35,7 @@ namespace Xero.NetStandard.OAuth2.Model.PayrollUk
         /// The payment method code
         /// </summary>
         /// <value>The payment method code</value>
-        [JsonConverter(typeof(StringEnumConverter))]
+        [JsonConverter(typeof(Client.CustomStringEnumConverter))]
         public enum PaymentMethodEnum
         {
             /// <summary>

--- a/Xero.NetStandard.OAuth2/Model/PayrollUk/SalaryAndWage.cs
+++ b/Xero.NetStandard.OAuth2/Model/PayrollUk/SalaryAndWage.cs
@@ -35,7 +35,7 @@ namespace Xero.NetStandard.OAuth2.Model.PayrollUk
         /// The current status of the corresponding salary and wages
         /// </summary>
         /// <value>The current status of the corresponding salary and wages</value>
-        [JsonConverter(typeof(StringEnumConverter))]
+        [JsonConverter(typeof(Client.CustomStringEnumConverter))]
         public enum StatusEnum
         {
             /// <summary>
@@ -68,7 +68,7 @@ namespace Xero.NetStandard.OAuth2.Model.PayrollUk
         /// The type of the payment of the corresponding salary and wages
         /// </summary>
         /// <value>The type of the payment of the corresponding salary and wages</value>
-        [JsonConverter(typeof(StringEnumConverter))]
+        [JsonConverter(typeof(Client.CustomStringEnumConverter))]
         public enum PaymentTypeEnum
         {
             /// <summary>

--- a/Xero.NetStandard.OAuth2/Model/PayrollUk/StatutoryDeductionCategory.cs
+++ b/Xero.NetStandard.OAuth2/Model/PayrollUk/StatutoryDeductionCategory.cs
@@ -30,7 +30,7 @@ namespace Xero.NetStandard.OAuth2.Model.PayrollUk
     /// </summary>
     /// <value>Statutory Deduction Category</value>
     
-    [JsonConverter(typeof(StringEnumConverter))]
+    [JsonConverter(typeof(Client.CustomStringEnumConverter))]
     
     public enum StatutoryDeductionCategory
     {

--- a/Xero.NetStandard.OAuth2/Model/PayrollUk/Timesheet.cs
+++ b/Xero.NetStandard.OAuth2/Model/PayrollUk/Timesheet.cs
@@ -35,7 +35,7 @@ namespace Xero.NetStandard.OAuth2.Model.PayrollUk
         /// Status of the timesheet
         /// </summary>
         /// <value>Status of the timesheet</value>
-        [JsonConverter(typeof(StringEnumConverter))]
+        [JsonConverter(typeof(Client.CustomStringEnumConverter))]
         public enum StatusEnum
         {
             /// <summary>

--- a/Xero.NetStandard.OAuth2/Model/Project/ChargeType.cs
+++ b/Xero.NetStandard.OAuth2/Model/Project/ChargeType.cs
@@ -30,7 +30,7 @@ namespace Xero.NetStandard.OAuth2.Model.Project
     /// </summary>
     /// <value>Can be &#x60;TIME&#x60;, &#x60;FIXED&#x60; or &#x60;NON_CHARGEABLE&#x60;, defines how the task will be charged. Use &#x60;TIME&#x60; when you want to charge per hour and &#x60;FIXED&#x60; to charge as a fixed amount. If the task will not be charged use &#x60;NON_CHARGEABLE&#x60;.</value>
     
-    [JsonConverter(typeof(StringEnumConverter))]
+    [JsonConverter(typeof(Client.CustomStringEnumConverter))]
     
     public enum ChargeType
     {

--- a/Xero.NetStandard.OAuth2/Model/Project/CurrencyCode.cs
+++ b/Xero.NetStandard.OAuth2/Model/Project/CurrencyCode.cs
@@ -30,7 +30,7 @@ namespace Xero.NetStandard.OAuth2.Model.Project
     /// </summary>
     /// <value>3 letter alpha code for the ISO-4217 currency code, e.g. USD, AUD.</value>
     
-    [JsonConverter(typeof(StringEnumConverter))]
+    [JsonConverter(typeof(Client.CustomStringEnumConverter))]
     
     public enum CurrencyCode
     {

--- a/Xero.NetStandard.OAuth2/Model/Project/ProjectStatus.cs
+++ b/Xero.NetStandard.OAuth2/Model/Project/ProjectStatus.cs
@@ -30,7 +30,7 @@ namespace Xero.NetStandard.OAuth2.Model.Project
     /// </summary>
     /// <value>Status for project</value>
     
-    [JsonConverter(typeof(StringEnumConverter))]
+    [JsonConverter(typeof(Client.CustomStringEnumConverter))]
     
     public enum ProjectStatus
     {

--- a/Xero.NetStandard.OAuth2/Model/Project/Task.cs
+++ b/Xero.NetStandard.OAuth2/Model/Project/Task.cs
@@ -40,7 +40,7 @@ namespace Xero.NetStandard.OAuth2.Model.Project
         /// Status of the task. When a task of ChargeType is &#x60;FIXED&#x60; and the rate amount is invoiced the status will be set to &#x60;INVOICED&#x60; and can&#39;t be modified. A task with ChargeType of &#x60;TIME&#x60; or &#x60;NON_CHARGEABLE&#x60; cannot have a status of &#x60;INVOICED&#x60;. A &#x60;LOCKED&#x60; state indicates that the task is currently changing state (for example being invoiced) and can&#39;t be modified.
         /// </summary>
         /// <value>Status of the task. When a task of ChargeType is &#x60;FIXED&#x60; and the rate amount is invoiced the status will be set to &#x60;INVOICED&#x60; and can&#39;t be modified. A task with ChargeType of &#x60;TIME&#x60; or &#x60;NON_CHARGEABLE&#x60; cannot have a status of &#x60;INVOICED&#x60;. A &#x60;LOCKED&#x60; state indicates that the task is currently changing state (for example being invoiced) and can&#39;t be modified.</value>
-        [JsonConverter(typeof(StringEnumConverter))]
+        [JsonConverter(typeof(Client.CustomStringEnumConverter))]
         public enum StatusEnum
         {
             /// <summary>

--- a/Xero.NetStandard.OAuth2/Model/Project/TimeEntry.cs
+++ b/Xero.NetStandard.OAuth2/Model/Project/TimeEntry.cs
@@ -35,7 +35,7 @@ namespace Xero.NetStandard.OAuth2.Model.Project
         /// Status of the time entry. By default a time entry is created with status of &#x60;ACTIVE&#x60;. A &#x60;LOCKED&#x60; state indicates that the time entry is currently changing state (for example being invoiced). Updates are not allowed when in this state. It will have a status of INVOICED once it is invoiced.
         /// </summary>
         /// <value>Status of the time entry. By default a time entry is created with status of &#x60;ACTIVE&#x60;. A &#x60;LOCKED&#x60; state indicates that the time entry is currently changing state (for example being invoiced). Updates are not allowed when in this state. It will have a status of INVOICED once it is invoiced.</value>
-        [JsonConverter(typeof(StringEnumConverter))]
+        [JsonConverter(typeof(Client.CustomStringEnumConverter))]
         public enum StatusEnum
         {
             /// <summary>


### PR DESCRIPTION
- also set all Model enums to use it

Enums were being deserialised differently depending on whether they are missing from the JSON or explicitly set to null:
```json
{
  "Property": null
}
```
--> throws an exception, meaning that the model is not returned

```json
{}
```
--> enum set to 0, model returned

This change normalises deserialisation of enums so that both cases are set to 0.
Other types are unaffected.