### PR TITLE
Default status to deleted on PaymentDelete

### DIFF
--- a/Xero.NetStandard.OAuth2/Model/Accounting/PaymentDelete.cs
+++ b/Xero.NetStandard.OAuth2/Model/Accounting/PaymentDelete.cs
@@ -36,7 +36,8 @@ namespace Xero.NetStandard.OAuth2.Model.Accounting
         /// </summary>
         [JsonConstructorAttribute]
         public PaymentDelete() 
-        { 
+        {
+            Status = Payment.StatusEnum.DELETED;
         }
         
         /// <summary>
@@ -44,7 +45,7 @@ namespace Xero.NetStandard.OAuth2.Model.Accounting
         /// </summary>
         /// <value>The status of the payment.</value>
         [DataMember(Name="Status", EmitDefaultValue=false)]
-        public string Status { get; set; }
+        public Payment.StatusEnum Status { get; set; }
 
         /// <summary>
         /// Returns the string presentation of the object


### PR DESCRIPTION
The `Status` property on `PaymentDelete` can default to a Deleted status as the request object is only used to hit a Delete endpoint, so is the only valid value of the property