### PR TITLE
Generated SDK doc for Accounting API

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This code is generated from the openapi-generator based on [Xero OpenAPI 3.0 Spe
 [![NuGet.org](https://img.shields.io/badge/NuGet.org-Xero.NetStandard.OAuth2-brightgreen?style=plastic&logo=appveyor)](https://www.nuget.org/packages/Xero.NetStandard.OAuth2/)
 
 # Current release of SDK with OAuth2 support
-Version Xero-NetStandard SDK only supports OAuth2 authentication and the following API sets.
+Xero-NetStandard SDK supports OAuth2 authentication and the following API sets.
 * accounting
 * fixed asset
 * identity
@@ -15,6 +15,15 @@ Version Xero-NetStandard SDK only supports OAuth2 authentication and the followi
 * projects
 * bank feeds
 * files 
+
+# Documentation
+
+## Xero API Documentaion
+For full Xero API documentation please visi [developer portal documentation](https://developer.xero.com/documentation/).
+
+## API Client Docs
+* Core [Accounting Api Docs](https://xeroapi.github.io/xero-ruby/accounting/index.html)
+
 
 ## How to handle OAuth 2.0 authentication & authorization?
 We have built Xero OAuth 2.0 Client. Check out [Xero.NetStandard.OAuth2Client](https://github.com/XeroAPI/Xero-NetStandard/tree/master/Xero.NetStandard.OAuth2Client)


### PR DESCRIPTION
Accounting API methods now had working examples in auto-generated docs under /docs/accounting/index.html. 

Readme.md updated to include the link. 

Github pages is turned on on the repo. 