### PR TITLE
added missing interfaces in IXeroClient.cs

### DIFF
--- a/Xero.NetStandard.OAuth2Client/Xero.NetStandard.OAuth2Client.csproj
+++ b/Xero.NetStandard.OAuth2Client/Xero.NetStandard.OAuth2Client.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <PackageId>Xero.NetStandard.OAuth2Client</PackageId>
-    <Version>1.3.0</Version>
+    <Version>1.3.1</Version>
     <Authors>Xero</Authors>
     <Company>Xero</Company>
     <PackageLicenseUrl>https://github.com/XeroAPI/Xero-NetStandard/</PackageLicenseUrl>

--- a/Xero.NetStandard.OAuth2Client/src/Client/IXeroClient.cs
+++ b/Xero.NetStandard.OAuth2Client/src/Client/IXeroClient.cs
@@ -10,12 +10,17 @@ namespace Xero.NetStandard.OAuth2.Client
     {
         XeroConfiguration xeroConfiguration { get; set; }
         string BuildLoginUri();
+        string BuildLoginUri(string state);
+        string BuildLoginUri(string state, string scope);
         string BuildLoginUriPkce(string codeVerifier);
+        string BuildLoginUriPkce(string codeVerifier, string state);
+        string BuildLoginUriPkce(string codeVerifier, string state, string scope);
         Task<IXeroToken> RequestAccessTokenAsync(string code);
         Task<IXeroToken> RequestAccessTokenPkceAsync(string code, string codeVerifier);
         Task<IXeroToken> RefreshAccessTokenAsync(IXeroToken xeroToken);
         Task<IXeroToken> GetCurrentValidTokenAsync(IXeroToken xeroToken);
         Task<List<Tenant>> GetConnectionsAsync(IXeroToken xeroToken);
         Task DeleteConnectionAsync(IXeroToken xeroToken, Tenant xeroTenant);
+        Task RevokeAccessTokenAsync(IXeroToken xeroToken);
     }
 }


### PR DESCRIPTION
added the following interface to IXeroClient.cs as reported by [issue 337](https://github.com/XeroAPI/Xero-NetStandard/issues/337)

BuildLoginUri(string state);
BuildLoginUri(string state, string scope);
BuildLoginUriPkce(string codeVerifier, string state);
BuildLoginUriPkce(string codeVerifier, string state, string scope);
RevokeAccessTokenAsync(IXeroToken xeroToken);

Version updated to 1.3.1