### PR TITLE
Fixed casing in JS

### DIFF
--- a/docs/accounting/index.html
+++ b/docs/accounting/index.html
@@ -5789,7 +5789,7 @@ ul.nav-tabs {
             } else if (location.includes('php')){
               sdkLang = 'php'
               sdkName = 'xero-php-oauth2'
-            } else if (location.includes('Xero-NetStandard') || location.includes('csharp')){
+            } else if (location.includes('xero-netstandard') || location.includes('csharp')){
               sdkLang = 'dotnet'
               sdkName = 'Xero-NetStandard'
             } else if (location.includes('java')){


### PR DESCRIPTION
Fixed a casing typo in the javascript for accounting docs which was causing an issue on the documentation header