### PR TITLE
Add INVOICED to Time Entry StatusEnum

### DIFF
--- a/Xero.NetStandard.OAuth2/Model/Project/TimeEntry.cs
+++ b/Xero.NetStandard.OAuth2/Model/Project/TimeEntry.cs
@@ -47,7 +47,13 @@ namespace Xero.NetStandard.OAuth2.Model.Project
             /// Enum LOCKED for value: LOCKED
             /// </summary>
             [EnumMember(Value = "LOCKED")]
-            LOCKED = 2
+            LOCKED = 2,
+
+            /// <summary>
+            /// Enum INVOICED for value: INVOICED
+            /// </summary>
+            [EnumMember(Value = "INVOICED")]
+            INVOICED = 3
 
         }
 


### PR DESCRIPTION
Fix for issue #355. Time entry statusenum is missing the INVOICED status, causes INVOICED time entries to not be returned