### PR TITLE
Refactor client to support custom connections for app store

### DIFF
--- a/README.md
+++ b/README.md
@@ -446,7 +446,7 @@ var client = new XeroClient(xconfig);
 | client.`DeleteConnectionAsync(IXeroToken xeroToken, Tenant xeroTenant)` | List of remaining Tenants attached to accesstoken
 | client.`RevokeAccessTokenAsync(IXeroToken xeroToken)` | Revokes a IXeroToken and returns null
 | client.`RefreshAccessTokenAsync(IXeroToken xeroToken)` | Returns a IXeroToken
-| client.`RequestClientCredentialsTokenAsync()` | Returns a IXeroToken
+| client.`RequestClientCredentialsTokenAsync(Boolean fetchTenants=true)` | Returns a IXeroToken, and defaults to calling GetConnections unless specified
 | client.`RequestAccessTokenAsync(string code)` | Returns a IXeroToken
 | client.`RequestAccessTokenPkceAsync(string code, string codeVerifier)` | Returns a IXeroToken
 | client.`GetCurrentValidTokenAsync(IXeroToken xeroToken)` | Returns a IXeroToken

--- a/Xero.NetStandard.OAuth2Client/Xero.NetStandard.OAuth2Client.csproj
+++ b/Xero.NetStandard.OAuth2Client/Xero.NetStandard.OAuth2Client.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <PackageId>Xero.NetStandard.OAuth2Client</PackageId>
-    <Version>1.4.0</Version>
+    <Version>1.5.0</Version>
     <Authors>Xero</Authors>
     <Company>Xero</Company>
     <PackageLicenseUrl>https://github.com/XeroAPI/Xero-NetStandard/</PackageLicenseUrl>

--- a/Xero.NetStandard.OAuth2Client/src/Client/XeroClient.cs
+++ b/Xero.NetStandard.OAuth2Client/src/Client/XeroClient.cs
@@ -166,7 +166,7 @@ namespace Xero.NetStandard.OAuth2.Client
         /// Requests a fully formed IXeroToken with list of tenants filled
         /// </summary>
         /// <returns></returns>
-        public async Task<IXeroToken> RequestClientCredentialsTokenAsync()
+        public async Task<IXeroToken> RequestClientCredentialsTokenAsync(Boolean fetchTenants=true)
         {
 
             var response = await _httpClient.RequestClientCredentialsTokenAsync(new ClientCredentialsTokenRequest
@@ -187,7 +187,9 @@ namespace Xero.NetStandard.OAuth2.Client
                 AccessToken = response.AccessToken,
                 ExpiresAtUtc = DateTime.UtcNow.AddSeconds(response.ExpiresIn)
             };
-            xeroToken.Tenants = await GetConnectionsAsync(xeroToken);
+            if(fetchTenants){
+                xeroToken.Tenants = await GetConnectionsAsync(xeroToken);
+            }
             return xeroToken;
 
         }


### PR DESCRIPTION
This defaults param to true, but allows you to not 'fetch connections' so that you can use client credentials with out fetching tenants for generating a marketplace billing token.