### PR TITLE
Pass in acrValues

### DIFF
--- a/Xero.NetStandard.OAuth2Client/src/Client/IXeroClient.cs
+++ b/Xero.NetStandard.OAuth2Client/src/Client/IXeroClient.cs
@@ -12,6 +12,7 @@ namespace Xero.NetStandard.OAuth2.Client
         string BuildLoginUri();
         string BuildLoginUri(string state);
         string BuildLoginUri(string state, string scope);
+        string BuildLoginUri(string state, string scope, string acrValues);
         string BuildLoginUriPkce(string codeVerifier);
         string BuildLoginUriPkce(string codeVerifier, string state);
         string BuildLoginUriPkce(string codeVerifier, string state, string scope);

--- a/Xero.NetStandard.OAuth2Client/src/Client/XeroClient.cs
+++ b/Xero.NetStandard.OAuth2Client/src/Client/XeroClient.cs
@@ -62,17 +62,25 @@ namespace Xero.NetStandard.OAuth2.Client
         /// <returns>A valid initial redirect URI for Xero OAuth 2.0 authorisation flow.</returns>
         public string BuildLoginUri(string state, string scope)
         {
+            return BuildLoginUri(state, scope, xeroConfiguration.AcrValues);
+        }
+
+        /// <summary>
+        /// Builds a XeroLogin URL for code flow, allows state, scope and acrValues to be passed in.
+        /// </summary>
+        /// <returns>A valid initial redirect URI for Xero OAuth 2.0 authorisation flow.</returns>
+        public string BuildLoginUri(string state, string scope, string acrValues)
+        { 
             var url = _xeroAuthorizeUri.CreateAuthorizeUrl(
                 clientId: xeroConfiguration.ClientId,
                 responseType: "code",
                 redirectUri: xeroConfiguration.CallbackUri.AbsoluteUri,
                 state: state,
-                scope: scope
+                scope: scope,
+                acrValues: acrValues
             );
             return url;
         }
-
-
 
         /// <summary>
         /// Builds a XeroLogin URL for PKCE flow with codeVerifier input

--- a/Xero.NetStandard.OAuth2Client/src/Config/XeroConfiguration.cs
+++ b/Xero.NetStandard.OAuth2Client/src/Config/XeroConfiguration.cs
@@ -10,5 +10,6 @@ namespace Xero.NetStandard.OAuth2.Config
         public Uri CallbackUri { get; set; }
         public string Scope { get; set; }
         public string State { get; set; }
+        public string AcrValues { get; set; }
     }
 }


### PR DESCRIPTION
This allows [Bulk Connections](https://developer.xero.com/documentation/oauth2/partner-benefits#bulkconnections) to be enabled / disabled as required

Followed the style on from the existing way that the methods are called. Backward compatible change; only change to the API is an additional method so it won't cause any issues for anyone already using the API