### PR TITLE
Additional dependency required for OAuth2.Client fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -738,7 +738,6 @@ var response = await FilesApi.UploadFileAsync(
     null,
     byteArray,
     file.FileName,
-    file.FileName,
     file.ContentType
 );
 ```

--- a/Xero.NetStandard.OAuth2Client/Xero.NetStandard.OAuth2Client.csproj
+++ b/Xero.NetStandard.OAuth2Client/Xero.NetStandard.OAuth2Client.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <PackageId>Xero.NetStandard.OAuth2Client</PackageId>
-    <Version>1.5.0</Version>
+    <Version>1.5.1</Version>
     <Authors>Xero</Authors>
     <Company>Xero</Company>
     <PackageLicenseUrl>https://github.com/XeroAPI/Xero-NetStandard/</PackageLicenseUrl>
@@ -13,5 +13,6 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="IdentityModel" Version="5.1.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
The Newtonsoft.Json package is required to build the package, unclear why it wasn't already included.

This should now be ready for release (OAuth2.Client only, SDK release is not required)

