### PR TITLE
Update RestSharp to first 106.x version not affected by CVE-2021-27293

### DIFF
--- a/Xero.NetStandard.OAuth2.Test/Xero.NetStandard.OAuth2.Test.csproj
+++ b/Xero.NetStandard.OAuth2.Test/Xero.NetStandard.OAuth2.Test.csproj
@@ -10,20 +10,20 @@
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>
   <ItemGroup>
-	  <PackageReference Include="CompareNETObjects" Version="4.57.0"/>
-	  <PackageReference Include="JsonSubTypes" Version="1.5.2"/>
-	  <PackageReference Include="Newtonsoft.Json" Version="12.0.1"/>
-	  <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0"/>
-	  <PackageReference Include="xunit" Version="2.4.1"/>
-	  <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1"/>
-	  <PackageReference Include="RestSharp" Version="106.12.0"/>
-	  <PackageReference Include="System.ComponentModel.Annotations" Version="4.5.0"/>
-	  <PackageReference Include="Microsoft.Extensions.Configuration" Version="*"/>
-	  <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="3.1.0"/>
-	  <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.0"/>
-	  <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="3.1.0"/>
-	  <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="3.1.0"/>
-	  <PackageReference Include="AutoBogus" Version="2.7.4"/>
+    <PackageReference Include="CompareNETObjects" Version="4.57.0"/>
+    <PackageReference Include="JsonSubTypes" Version="1.5.2"/>
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.1"/>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0"/>
+    <PackageReference Include="xunit" Version="2.4.1"/>
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1"/>
+    <PackageReference Include="RestSharp" Version="106.12.0"/>
+    <PackageReference Include="System.ComponentModel.Annotations" Version="4.5.0"/>
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="*"/>
+    <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="3.1.0"/>
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.0"/>
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="3.1.0"/>
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="3.1.0"/>
+    <PackageReference Include="AutoBogus" Version="2.7.4"/>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Xero.NetStandard.OAuth2\Xero.NetStandard.OAuth2.csproj">

--- a/Xero.NetStandard.OAuth2.Test/Xero.NetStandard.OAuth2.Test.csproj
+++ b/Xero.NetStandard.OAuth2.Test/Xero.NetStandard.OAuth2.Test.csproj
@@ -10,20 +10,20 @@
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="CompareNETObjects" Version="4.57.0"/>
-    <PackageReference Include="JsonSubTypes" Version="1.5.2"/>
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.1"/>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0"/>
-    <PackageReference Include="xunit" Version="2.4.1"/>
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1"/>
-    <PackageReference Include="RestSharp" Version="106.11.4"/>
-    <PackageReference Include="System.ComponentModel.Annotations" Version="4.5.0"/>
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="*"/>
-    <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="3.1.0"/>
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.0"/>
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="3.1.0"/>
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="3.1.0"/>
-    <PackageReference Include="AutoBogus" Version="2.7.4"/>
+	  <PackageReference Include="CompareNETObjects" Version="4.57.0"/>
+	  <PackageReference Include="JsonSubTypes" Version="1.5.2"/>
+	  <PackageReference Include="Newtonsoft.Json" Version="12.0.1"/>
+	  <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0"/>
+	  <PackageReference Include="xunit" Version="2.4.1"/>
+	  <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1"/>
+	  <PackageReference Include="RestSharp" Version="106.12.0"/>
+	  <PackageReference Include="System.ComponentModel.Annotations" Version="4.5.0"/>
+	  <PackageReference Include="Microsoft.Extensions.Configuration" Version="*"/>
+	  <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="3.1.0"/>
+	  <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.0"/>
+	  <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="3.1.0"/>
+	  <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="3.1.0"/>
+	  <PackageReference Include="AutoBogus" Version="2.7.4"/>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Xero.NetStandard.OAuth2\Xero.NetStandard.OAuth2.csproj">

--- a/Xero.NetStandard.OAuth2/Xero.NetStandard.OAuth2.csproj
+++ b/Xero.NetStandard.OAuth2/Xero.NetStandard.OAuth2.csproj
@@ -30,7 +30,7 @@
       <PackageReference Include="CompareNETObjects" Version="4.57.0" />
       <PackageReference Include="JsonSubTypes" Version="1.5.2" />
       <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
-      <PackageReference Include="RestSharp" Version="106.11.4" />
+      <PackageReference Include="RestSharp" Version="106.12.0" />
       <PackageReference Include="System.ComponentModel.Annotations" Version="4.5.0" />
   </ItemGroup>
 


### PR DESCRIPTION
https://github.com/advisories/GHSA-9pq7-rcxv-47vq