### PR TITLE
Restsharp version bump

### DIFF
--- a/Xero.NetStandard.OAuth2/Client/ApiClient.cs
+++ b/Xero.NetStandard.OAuth2/Client/ApiClient.cs
@@ -177,7 +177,7 @@ namespace Xero.NetStandard.OAuth2.Client
             get { return _contentType; }
             set { throw new InvalidOperationException("Not allowed to set content type."); }
         }
-
+        
         public string Serialize(Parameter parameter)
         {
             return Serialize(parameter.Value);
@@ -335,7 +335,7 @@ namespace Xero.NetStandard.OAuth2.Client
             if (path == null) throw new ArgumentNullException("path");
             if (options == null) throw new ArgumentNullException("options");
             if (configuration == null) throw new ArgumentNullException("configuration");
-
+            
             RestRequest request = new RestRequest(path, Method(method))
             {
                 Timeout = configuration.Timeout
@@ -493,11 +493,7 @@ namespace Xero.NetStandard.OAuth2.Client
 
         private async Task<ApiResponse<T>> Exec<T>(RestRequest req, IReadableConfiguration configuration)
         {
-            RestClient client = new RestClient(_baseUrl);
-
-            client.ClearHandlers();
-            var existingDeserializer = req.JsonSerializer as IDeserializer;
-            if (existingDeserializer != null)
+            RestClientOptions clientOptions = new RestClientOptions(_baseUrl)
             {
                 MaxTimeout = configuration.Timeout
             };
@@ -523,7 +519,6 @@ namespace Xero.NetStandard.OAuth2.Client
                     client.CookieContainer.Add(new Cookie(cookie.Name, cookie.Value));
                 }
             }
-
 
             InterceptRequest(req);
             var response = await client.ExecuteAsync<T>(req);

--- a/Xero.NetStandard.OAuth2/Client/ApiClient.cs
+++ b/Xero.NetStandard.OAuth2/Client/ApiClient.cs
@@ -493,11 +493,14 @@ namespace Xero.NetStandard.OAuth2.Client
 
         private async Task<ApiResponse<T>> Exec<T>(RestRequest req, IReadableConfiguration configuration)
         {
-            RestClientOptions clientOptions = new RestClientOptions(_baseUrl)
+            RestClient client = new RestClient(_baseUrl);
+
+            client.ClearHandlers();
+            var existingDeserializer = req.JsonSerializer as IDeserializer;
+            if (existingDeserializer != null)
             {
                 MaxTimeout = configuration.Timeout
             };
-
             if (configuration.UserAgent != null)
             {
                 clientOptions.UserAgent = configuration.UserAgent;

--- a/Xero.NetStandard.OAuth2/Client/Configuration.cs
+++ b/Xero.NetStandard.OAuth2/Client/Configuration.cs
@@ -31,7 +31,7 @@ namespace Xero.NetStandard.OAuth2.Client
         /// Version of the package.
         /// </summary>
         /// <value>Version of the package.</value>
-        public const string Version = "3.28.0";
+        public const string Version = "3.28.1";
 
         /// <summary>
         /// Identifier for ISO 8601 DateTime Format
@@ -103,7 +103,7 @@ namespace Xero.NetStandard.OAuth2.Client
         [System.Diagnostics.CodeAnalysis.SuppressMessage("ReSharper", "VirtualMemberCallInConstructor")]
         public Configuration()
         {
-            UserAgent = "xero-netstandard-3.28.0";
+            UserAgent = "xero-netstandard-3.28.1";
             BasePath = "https://api.xero.com/api.xro/2.0";
             DefaultHeader = new ConcurrentDictionary<string, string>();
             ApiKey = new ConcurrentDictionary<string, string>();
@@ -342,7 +342,7 @@ namespace Xero.NetStandard.OAuth2.Client
             String report = "C# SDK (Xero.NetStandard.OAuth2) Debug Report:\n";
             report += "    OS: " + System.Runtime.InteropServices.RuntimeInformation.OSDescription + "\n";
             report += "    Version of the API: 2.29.2\n";
-            report += "    SDK Package Version: 3.28.0\n";
+            report += "    SDK Package Version: 3.28.1\n";
 
             return report;
         }

--- a/Xero.NetStandard.OAuth2/Xero.NetStandard.OAuth2.csproj
+++ b/Xero.NetStandard.OAuth2/Xero.NetStandard.OAuth2.csproj
@@ -16,7 +16,7 @@
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
     <RootNamespace>Xero.NetStandard.OAuth2</RootNamespace>
-    <Version>3.28.0</Version>
+    <Version>3.28.1</Version>
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\Xero.NetStandard.OAuth2.xml</DocumentationFile>
     <PackageLicenseUrl>https://github.com/XeroAPI/Xero-NetStandard/</PackageLicenseUrl>
     <PackageIconUrl>https://en.gravatar.com/userimage/180557955/74b3a957d886bc921b0d1455beed9dab.png</PackageIconUrl>

--- a/docs/accounting/index.html
+++ b/docs/accounting/index.html
@@ -6070,7 +6070,7 @@ ul.nav-tabs {
           <nav id="scrollingNav">
             <ul class="sidenav nav nav-list">
               <li class="nav-header" data-group="Accounting"><strong>SDK: </strong><span id='sdk-name'></span></li>
-              <li class="nav-header" data-group="Accounting"><strong>VSN: </strong>3.28.0</li>
+              <li class="nav-header" data-group="Accounting"><strong>VSN: </strong>3.28.1</li>
               <li class="nav-header" data-group="Accounting"><a href="#api-Accounting">Methods</a></li>
               <li data-group="Accounting" data-name="createAccount" class="">
                 <a href="#api-Accounting-createAccount">createAccount</a>

--- a/docs/appstore/index.html
+++ b/docs/appstore/index.html
@@ -1142,7 +1142,7 @@ ul.nav-tabs {
           <nav id="scrollingNav">
             <ul class="sidenav nav nav-list">
               <li class="nav-header" data-group="AppStore"><strong>SDK: </strong><span id='sdk-name'></span></li>
-              <li class="nav-header" data-group="AppStore"><strong>VSN: </strong>3.28.0</li>
+              <li class="nav-header" data-group="AppStore"><strong>VSN: </strong>3.28.1</li>
               <li class="nav-header" data-group="AppStore"><a href="#api-AppStore">Methods</a></li>
               <li data-group="AppStore" data-name="getSubscription" class="">
                 <a href="#api-AppStore-getSubscription">getSubscription</a>

--- a/docs/bankfeeds/index.html
+++ b/docs/bankfeeds/index.html
@@ -1269,7 +1269,7 @@ ul.nav-tabs {
           <nav id="scrollingNav">
             <ul class="sidenav nav nav-list">
               <li class="nav-header" data-group="BankFeeds"><strong>SDK: </strong><span id='sdk-name'></span></li>
-              <li class="nav-header" data-group="BankFeeds"><strong>VSN: </strong>3.28.0</li>
+              <li class="nav-header" data-group="BankFeeds"><strong>VSN: </strong>3.28.1</li>
               <li class="nav-header" data-group="BankFeeds"><a href="#api-BankFeeds">Methods</a></li>
               <li data-group="BankFeeds" data-name="createFeedConnections" class="">
                 <a href="#api-BankFeeds-createFeedConnections">createFeedConnections</a>

--- a/docs/files/index.html
+++ b/docs/files/index.html
@@ -1156,7 +1156,7 @@ ul.nav-tabs {
           <nav id="scrollingNav">
             <ul class="sidenav nav nav-list">
               <li class="nav-header" data-group="Files"><strong>SDK: </strong><span id='sdk-name'></span></li>
-              <li class="nav-header" data-group="Files"><strong>VSN: </strong>3.28.0</li>
+              <li class="nav-header" data-group="Files"><strong>VSN: </strong>3.28.1</li>
               <li class="nav-header" data-group="Files"><a href="#api-Files">Methods</a></li>
               <li data-group="Files" data-name="createFileAssociation" class="">
                 <a href="#api-Files-createFileAssociation">createFileAssociation</a>

--- a/docs/finance/index.html
+++ b/docs/finance/index.html
@@ -2719,7 +2719,7 @@ ul.nav-tabs {
           <nav id="scrollingNav">
             <ul class="sidenav nav nav-list">
               <li class="nav-header" data-group="Finance"><strong>SDK: </strong><span id='sdk-name'></span></li>
-              <li class="nav-header" data-group="Finance"><strong>VSN: </strong>3.28.0</li>
+              <li class="nav-header" data-group="Finance"><strong>VSN: </strong>3.28.1</li>
               <li class="nav-header" data-group="Finance"><a href="#api-Finance">Methods</a></li>
               <li data-group="Finance" data-name="getAccountingActivityAccountUsage" class="">
                 <a href="#api-Finance-getAccountingActivityAccountUsage">getAccountingActivityAccountUsage</a>

--- a/docs/payroll-au/index.html
+++ b/docs/payroll-au/index.html
@@ -3275,7 +3275,7 @@ ul.nav-tabs {
           <nav id="scrollingNav">
             <ul class="sidenav nav nav-list">
               <li class="nav-header" data-group="PayrollAu"><strong>SDK: </strong><span id='sdk-name'></span></li>
-              <li class="nav-header" data-group="PayrollAu"><strong>VSN: </strong>3.28.0</li>
+              <li class="nav-header" data-group="PayrollAu"><strong>VSN: </strong>3.28.1</li>
               <li class="nav-header" data-group="PayrollAu"><a href="#api-PayrollAu">Methods</a></li>
               <li data-group="PayrollAu" data-name="createEmployee" class="">
                 <a href="#api-PayrollAu-createEmployee">createEmployee</a>

--- a/docs/payroll-nz/index.html
+++ b/docs/payroll-nz/index.html
@@ -3839,7 +3839,7 @@ ul.nav-tabs {
           <nav id="scrollingNav">
             <ul class="sidenav nav nav-list">
               <li class="nav-header" data-group="PayrollNz"><strong>SDK: </strong><span id='sdk-name'></span></li>
-              <li class="nav-header" data-group="PayrollNz"><strong>VSN: </strong>3.28.0</li>
+              <li class="nav-header" data-group="PayrollNz"><strong>VSN: </strong>3.28.1</li>
               <li class="nav-header" data-group="PayrollNz"><a href="#api-PayrollNz">Methods</a></li>
               <li data-group="PayrollNz" data-name="approveTimesheet" class="">
                 <a href="#api-PayrollNz-approveTimesheet">approveTimesheet</a>

--- a/docs/payroll-uk/index.html
+++ b/docs/payroll-uk/index.html
@@ -3511,7 +3511,7 @@ ul.nav-tabs {
           <nav id="scrollingNav">
             <ul class="sidenav nav nav-list">
               <li class="nav-header" data-group="PayrollUk"><strong>SDK: </strong><span id='sdk-name'></span></li>
-              <li class="nav-header" data-group="PayrollUk"><strong>VSN: </strong>3.28.0</li>
+              <li class="nav-header" data-group="PayrollUk"><strong>VSN: </strong>3.28.1</li>
               <li class="nav-header" data-group="PayrollUk"><a href="#api-PayrollUk">Methods</a></li>
               <li data-group="PayrollUk" data-name="approveTimesheet" class="">
                 <a href="#api-PayrollUk-approveTimesheet">approveTimesheet</a>

--- a/docs/projects/index.html
+++ b/docs/projects/index.html
@@ -1463,7 +1463,7 @@ ul.nav-tabs {
           <nav id="scrollingNav">
             <ul class="sidenav nav nav-list">
               <li class="nav-header" data-group="Project"><strong>SDK: </strong><span id='sdk-name'></span></li>
-              <li class="nav-header" data-group="Project"><strong>VSN: </strong>3.28.0</li>
+              <li class="nav-header" data-group="Project"><strong>VSN: </strong>3.28.1</li>
               <li class="nav-header" data-group="Project"><a href="#api-Project">Methods</a></li>
               <li data-group="Project" data-name="createProject" class="">
                 <a href="#api-Project-createProject">createProject</a>


### PR DESCRIPTION
Changes to upgrade to RestSharp 108 generated by codegen, as initially proposed by @AshleyMedway in this [PR](https://github.com/XeroAPI/Xero-NetStandard/pull/439). Manually tested using the sample app with all API calls and succeeds

## Changes
- Moves cookie handling logic into `Configuration` as RestSharp moves Cookie handling logic out of `RestRequest` class (into `RestClient`)
- `IRestResponse` and `IRestRequest` are deprecated and use `RestResponse` and `RestResponse`
- Implements `IRestSerializer` interface and implements respective methods/properties
