### PR TITLE
Fixed CreateBrandingThemePaymentServicesTest

### DIFF
--- a/Xero.NetStandard.OAuth2.Test/Api/AccountingApiTests.cs
+++ b/Xero.NetStandard.OAuth2.Test/Api/AccountingApiTests.cs
@@ -231,8 +231,8 @@ namespace Xero.NetStandard.OAuth2.Test.Api.Accounting
       // TODO uncomment below to test the method and replace null with proper value
       string xeroTenantId = AutoFaker.Generate<string>();
       Guid brandingThemeID = AutoFaker.Generate<Guid>();
-      PaymentService paymentService = new PaymentService();
-      var response = await instance.CreateBrandingThemePaymentServicesAsync(accessToken, xeroTenantId, brandingThemeID, paymentService).ConfigureAwait(false);
+      PaymentServices paymentServices = new PaymentServices();
+      var response = await instance.CreateBrandingThemePaymentServicesAsync(accessToken, xeroTenantId, brandingThemeID, paymentServices).ConfigureAwait(false);
       Assert.IsType<PaymentServices>(response);
     }
 


### PR DESCRIPTION
- [OAS 2.33.0](https://github.com/XeroAPI/Xero-OpenAPI/commit/460899330ec87a6037058e852c885513273dfc61#diff-b53ec75ca0b7c2853cabb35cc15832cea39975d3e7e5200a2162aff3b7e90227R3419) altered parameters of `CreateBrandingThemePaymentService` causing unit test to fail. 
- `PaymentServices` is now provided instead of `PaymentService`

## Types of Changes
 - [x]  Bug fix (non-breaking change that fixes an issue)
 - [ ] New feature (non-breaking change that adds functionality)
 - [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)