### PR TITLE
Updates RestSharp package to 110.2.0

### DIFF
--- a/Xero.NetStandard.OAuth2.Test/Xero.NetStandard.OAuth2.Test.csproj
+++ b/Xero.NetStandard.OAuth2.Test/Xero.NetStandard.OAuth2.Test.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
-    <PackageReference Include="RestSharp" Version="108.0.1" />
+    <PackageReference Include="RestSharp" Version="110.2.0" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="4.5.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="*" />
     <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="3.1.0" />

--- a/Xero.NetStandard.OAuth2/Client/ApiClient.cs
+++ b/Xero.NetStandard.OAuth2/Client/ApiClient.cs
@@ -34,7 +34,7 @@ namespace Xero.NetStandard.OAuth2.Client
     internal class CustomJsonCodec : IRestSerializer, ISerializer, IDeserializer
     {
         private readonly IReadableConfiguration _configuration;
-        private string _contentType = "application/json";
+        private ContentType _contentType = "application/json";
         private readonly JsonSerializerSettings _serializerSettings = new JsonSerializerSettings
         {
             // OpenAPI generated types generally hide default constructors.
@@ -173,7 +173,7 @@ namespace Xero.NetStandard.OAuth2.Client
         public string Namespace { get; set; }
         public string DateFormat { get; set; }
 
-        public string ContentType
+        public ContentType ContentType
         {
             get { return _contentType; }
             set { throw new InvalidOperationException("Not allowed to set content type."); }
@@ -198,7 +198,7 @@ namespace Xero.NetStandard.OAuth2.Client
             "*"
         };
 
-        public SupportsContentType SupportsContentType => type => AcceptedContentTypes.Contains(type);
+        public SupportsContentType SupportsContentType => type => AcceptedContentTypes.Contains(type.Value);
 
         public DataFormat DataFormat => DataFormat.Json;
     }
@@ -503,21 +503,21 @@ namespace Xero.NetStandard.OAuth2.Client
                 clientOptions.UserAgent = configuration.UserAgent;
             }
 
-            RestClient client = new RestClient(clientOptions);
-
-            client
-                .UseSerializer(() =>
+            RestClient client = new RestClient(
+                clientOptions,
+                configureSerialization: cs => cs.UseSerializer(() =>
                 {
                     var serializer = new CustomJsonCodec(configuration);
                     return serializer;
                 })
-                .UseSerializer<XmlRestSerializer>();
+                    .UseSerializer<XmlRestSerializer>()
+            );
 
             if (configuration.Cookies != null && configuration.Cookies.Count > 0)
             {
                 foreach (var cookie in configuration.Cookies)
                 {
-                    client.CookieContainer.Add(new Cookie(cookie.Name, cookie.Value));
+                    req.CookieContainer.Add(new Cookie(cookie.Name, cookie.Value));
                 }
             }
 

--- a/Xero.NetStandard.OAuth2/Client/Configuration.cs
+++ b/Xero.NetStandard.OAuth2/Client/Configuration.cs
@@ -31,7 +31,7 @@ namespace Xero.NetStandard.OAuth2.Client
         /// Version of the package.
         /// </summary>
         /// <value>Version of the package.</value>
-        public const string Version = "3.34.1";
+        public const string Version = "3.34.2";
 
         /// <summary>
         /// Identifier for ISO 8601 DateTime Format
@@ -103,7 +103,7 @@ namespace Xero.NetStandard.OAuth2.Client
         [System.Diagnostics.CodeAnalysis.SuppressMessage("ReSharper", "VirtualMemberCallInConstructor")]
         public Configuration()
         {
-            UserAgent = "xero-netstandard-3.34.1";
+            UserAgent = "xero-netstandard-3.34.2";
             BasePath = "https://api.xero.com/api.xro/2.0";
             DefaultHeader = new ConcurrentDictionary<string, string>();
             ApiKey = new ConcurrentDictionary<string, string>();
@@ -342,7 +342,7 @@ namespace Xero.NetStandard.OAuth2.Client
             String report = "C# SDK (Xero.NetStandard.OAuth2) Debug Report:\n";
             report += "    OS: " + System.Runtime.InteropServices.RuntimeInformation.OSDescription + "\n";
             report += "    Version of the API: 2.40.1\n";
-            report += "    SDK Package Version: 3.34.1\n";
+            report += "    SDK Package Version: 3.34.2\n";
 
             return report;
         }

--- a/Xero.NetStandard.OAuth2/Xero.NetStandard.OAuth2.csproj
+++ b/Xero.NetStandard.OAuth2/Xero.NetStandard.OAuth2.csproj
@@ -16,7 +16,7 @@
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
     <RootNamespace>Xero.NetStandard.OAuth2</RootNamespace>
-    <Version>3.34.1</Version>
+    <Version>3.34.2</Version>
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\Xero.NetStandard.OAuth2.xml</DocumentationFile>
     <PackageLicenseUrl>https://github.com/XeroAPI/Xero-NetStandard/</PackageLicenseUrl>
     <PackageIconUrl>https://en.gravatar.com/userimage/180557955/74b3a957d886bc921b0d1455beed9dab.png</PackageIconUrl>
@@ -30,7 +30,7 @@
       <PackageReference Include="CompareNETObjects" Version="4.57.0" />
       <PackageReference Include="JsonSubTypes" Version="1.5.2" />
       <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
-      <PackageReference Include="RestSharp" Version="108.0.1" />
+      <PackageReference Include="RestSharp" Version="110.2.0" />
       <PackageReference Include="System.ComponentModel.Annotations" Version="4.5.0" />
   </ItemGroup>
 


### PR DESCRIPTION
Build from OAS 2.40.1

Updates RestSharp dependency to 110.2.0. 

Bug Fixes

1. https://github.com/XeroAPI/Xero-NetStandard/issues/495
2. https://github.com/XeroAPI/Xero-NetStandard/issues/484
3. https://github.com/XeroAPI/Xero-NetStandard/issues/442
4. https://github.com/XeroAPI/Xero-NetStandard/issues/472