### PR TITLE
Add DateString to BankTransaction for API Data Consistency

### DIFF
--- a/Xero.NetStandard.OAuth2/Model/Accounting/BankTransaction.cs
+++ b/Xero.NetStandard.OAuth2/Model/Accounting/BankTransaction.cs
@@ -173,6 +173,12 @@ namespace Xero.NetStandard.OAuth2.Model.Accounting
         public bool? IsReconciled { get; set; }
 
         /// <summary>
+        /// String representation of the Date property in ISO 8601 format (YYYY-MM-DDTHH:MM:SS)
+        /// </summary>
+        [DataMember(Name="DateString", EmitDefaultValue=false)]
+        public string DateString { get; set; }
+
+        /// <summary>
         /// Date of transaction – YYYY-MM-DD
         /// </summary>
         /// <value>Date of transaction – YYYY-MM-DD</value>


### PR DESCRIPTION
This pull request introduces the `DateString` property to the `BankTransaction` class to ensure full alignment with the JSON structure received from the Xero API. 