### PR TITLE
Update DeleteConnectionAsync to use the correct connectionId rather t…

### DIFF
--- a/Xero.NetStandard.OAuth2Client/src/Client/IXeroClient.cs
+++ b/Xero.NetStandard.OAuth2Client/src/Client/IXeroClient.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Xero.NetStandard.OAuth2.Config;
@@ -22,6 +23,7 @@ namespace Xero.NetStandard.OAuth2.Client
         Task<IXeroToken> GetCurrentValidTokenAsync(IXeroToken xeroToken);
         Task<List<Tenant>> GetConnectionsAsync(IXeroToken xeroToken);
         Task DeleteConnectionAsync(IXeroToken xeroToken, Tenant xeroTenant);
+        Task DeleteConnectionAsync(IXeroToken xeroToken, Guid connectionId);
         Task RevokeAccessTokenAsync(IXeroToken xeroToken);
     }
 }

--- a/Xero.NetStandard.OAuth2Client/src/Client/XeroClient.cs
+++ b/Xero.NetStandard.OAuth2Client/src/Client/XeroClient.cs
@@ -316,9 +316,32 @@ namespace Xero.NetStandard.OAuth2.Client
         /// <param name="xeroToken"></param>
         /// <param name="xeroTenant"></param>
         /// <returns>List of Tenants attached to accesstoken</returns>
+        [Obsolete("This method is being removed. Switch to using DeleteConnectionAsync using the connectionId guid")]
         public async Task DeleteConnectionAsync(IXeroToken xeroToken, Tenant xeroTenant)
         {
             using (var requestMessage = new HttpRequestMessage(HttpMethod.Delete, $"{xeroConfiguration.XeroApiBaseUri}/connections" + "/" + xeroTenant.id))
+            {
+                requestMessage.Headers.Authorization = new AuthenticationHeaderValue("Bearer", xeroToken.AccessToken);
+
+                var result = await _httpClient.SendAsync(requestMessage);
+                if (result.StatusCode == System.Net.HttpStatusCode.NoContent)
+                {
+                    return;
+                }
+
+                throw new HttpRequestException(await result.Content.ReadAsStringAsync());
+            }
+        }
+
+        /// <summary>
+        /// Delete the connection given the accesstoken and xero tenant id
+        /// </summary>
+        /// <param name="xeroToken"></param>
+        /// <param name="connectionId"></param>
+        /// <returns>Delete a connection using its connection id</returns>
+        public async Task DeleteConnectionAsync(IXeroToken xeroToken, Guid connectionId)
+        {
+            using (var requestMessage = new HttpRequestMessage(HttpMethod.Delete, $"{xeroConfiguration.XeroApiBaseUri}/connections" + "/" + connectionId))
             {
                 requestMessage.Headers.Authorization = new AuthenticationHeaderValue("Bearer", xeroToken.AccessToken);
 


### PR DESCRIPTION
…han the xeroTenant ID.

The DeleteConnection API call is DELETE /connections/{connectionId} rather than DELETE /connections/{tenantId}. I have left the old method in place and added a new correct one, with the plan to remove the old one in the future (marked as Obsolete). This can also be just removed, as I don't believe it will work in its current state and the remote side will always respond with "Forbidden".