### PR TITLE
Fix OAuth2Client publish workflow to match existing OAuthClient-v tag convention

### DIFF
--- a/.github/workflows/publish-Oauth2Client-package.yml
+++ b/.github/workflows/publish-Oauth2Client-package.yml
@@ -35,7 +35,7 @@ jobs:
       id: check_changes
       run: |
         # Get last client tag
-        LAST_CLIENT_TAG=$(git tag -l 'client-*' --sort=-v:refname | head -n 1)
+        LAST_CLIENT_TAG=$(git tag -l 'OAuthClient-v*' --sort=-v:refname | head -n 1)
         echo "Found last client tag: $LAST_CLIENT_TAG"
         echo "last_client_tag=$LAST_CLIENT_TAG" >> $GITHUB_OUTPUT
 
@@ -71,7 +71,7 @@ jobs:
           exit 0
         fi
         
-        LAST_VERSION=${LAST_CLIENT_TAG#client-}
+        LAST_VERSION=${LAST_CLIENT_TAG#OAuthClient-v}
         echo "Last OAuth2Client version: $LAST_VERSION (tag: $LAST_CLIENT_TAG)"
         
         # Determine Bump Type from Main SDK tags
@@ -160,8 +160,8 @@ jobs:
         git push origin HEAD:master
         
         # Create and push the tag
-        git tag "client-${{steps.calc_version.outputs.version}}"
-        git push origin "client-${{steps.calc_version.outputs.version}}"
+        git tag "OAuthClient-v${{steps.calc_version.outputs.version}}"
+        git push origin "OAuthClient-v${{steps.calc_version.outputs.version}}"
       working-directory: Xero-NetStandard
       env:
         GH_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
## Problem

The [OAuth2Client publish workflow run](https://github.com/XeroAPI/Xero-NetStandard/actions/runs/29298619336) failed trying to push `Xero.NetStandard.OAuth2Client.1.6.0.nupkg` — a version that has been on nuget.org since May 2022.

Root cause: the `Check for changes` step looks for tags matching `client-*`, but the repo's client release tags use the `OAuthClient-v*` convention (`OAuthClient-v1.5.1`, `OAuthClient-v1.5.3`, `OAuthClient-v1.6.0`). With no matching tag, every run falls into the initial-release path: change detection is skipped (`has_changes` forced `true`) and the version falls back to the csproj value (1.6.0) instead of bumping.

## Fix

Align the workflow with the existing tag convention in all three places it appears:

- **Tag lookup** (L38): match `OAuthClient-v*`
- **Version parse** (L74): strip the `OAuthClient-v` prefix (including the `v`, so the bump arithmetic gets a plain `1.6.0`)
- **Tag creation** (L163-164): tag successful publishes as `OAuthClient-v<version>`, so subsequent runs find the new tag

## Expected behaviour after merge

Next `workflow_dispatch` run will find `OAuthClient-v1.6.0`, detect the unpublished OAuth2Client changes since then (IdentityModel 7.0.0 fix from #556, PETOSS-506 dependency bumps from #564), compute **1.6.1** (patch bump), publish it, and tag `OAuthClient-v1.6.1`.