### PR TITLE
[XAPI-2340] Switch NuGet publishing to Trusted Publishing (OIDC)

### DIFF
--- a/.github/workflows/publish-Oauth2-package.yml
+++ b/.github/workflows/publish-Oauth2-package.yml
@@ -18,6 +18,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+      id-token: write
 
     steps:
 
@@ -53,8 +54,14 @@ jobs:
       run: dotnet pack
       working-directory: Xero-NetStandard
 
+    - name: NuGet login (OIDC -> temp API key)
+      uses: NuGet/login@v1
+      id: nuget_login
+      with:
+        user: ${{ vars.NUGET_USER }}
+
     - name: Publish OAuth2 Package to Nuget.org
-      run: dotnet nuget push ./Xero.NetStandard.OAuth2/bin/Release/Xero.NetStandard.OAuth2.${{steps.get_latest_release_number.outputs.release_tag}}.nupkg --api-key ${{ secrets.NUGET_APIKEY }} --source https://api.nuget.org/v3/index.json
+      run: dotnet nuget push ./Xero.NetStandard.OAuth2/bin/Release/Xero.NetStandard.OAuth2.${{steps.get_latest_release_number.outputs.release_tag}}.nupkg --api-key ${{ steps.nuget_login.outputs.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json
       working-directory: Xero-NetStandard
 
   notify-codegen-repo:

--- a/.github/workflows/publish-Oauth2Client-package.yml
+++ b/.github/workflows/publish-Oauth2Client-package.yml
@@ -21,6 +21,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+      id-token: write
 
     steps:
 
@@ -141,9 +142,16 @@ jobs:
       run: dotnet pack ./Xero.NetStandard.OAuth2Client/Xero.NetStandard.OAuth2Client.csproj
       working-directory: Xero-NetStandard
 
+    - name: NuGet login (OIDC -> temp API key)
+      if: steps.check_changes.outputs.has_changes == 'true'
+      uses: NuGet/login@v1
+      id: nuget_login
+      with:
+        user: ${{ vars.NUGET_USER }}
+
     - name: Publish OAuth2Client Package to Nuget.org
       if: steps.check_changes.outputs.has_changes == 'true'
-      run: dotnet nuget push ./Xero.NetStandard.OAuth2Client/bin/Release/Xero.NetStandard.OAuth2Client.${{steps.calc_version.outputs.version}}.nupkg --api-key ${{ secrets.NUGET_APIKEY }} --source https://api.nuget.org/v3/index.json
+      run: dotnet nuget push ./Xero.NetStandard.OAuth2Client/bin/Release/Xero.NetStandard.OAuth2Client.${{steps.calc_version.outputs.version}}.nupkg --api-key ${{ steps.nuget_login.outputs.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json
       working-directory: Xero-NetStandard
 
     - name: Commit, Push and Tag


### PR DESCRIPTION
## Summary
- Switch both `publish-Oauth2-package.yml` and `publish-Oauth2Client-package.yml` from the long-lived `NUGET_APIKEY` secret to [NuGet Trusted Publishing](https://aka.ms/nuget/trusted-publishing) (OIDC-based, short-lived keys), using `NuGet/login@v1`.
- Root cause for switching now: the OAuth2Client publish has been failing since 2026-07-14 with a 403 ("API key is invalid, has expired, or does not have permission to access the specified package"), most likely because the key's package-scope glob on nuget.org never covered `Xero.NetStandard.OAuth2Client`. Trusted Publishing removes the recurring scoping problem and the long-lived secret entirely.

## Before this can be merged/run successfully
1. Add a repository variable `NUGET_USER` (Settings → Secrets and variables → Actions → Variables) set to the nuget.org profile name (not email) that owns these packages.
2. Register two Trusted Publishing policies on nuget.org (Account → Trusted Publishing):
   - Repo: `XeroAPI/Xero-NetStandard`, Workflow file: `publish-Oauth2-package.yml`, Environment: `prod`
   - Repo: `XeroAPI/Xero-NetStandard`, Workflow file: `publish-Oauth2Client-package.yml`, Environment: `prod`
3. Once merged, the `NUGET_APIKEY` secret can be removed (kept for now in case of rollback).

## Test plan
- [x] `NUGET_USER` repo variable set
- [x] Trusted Publishing policies registered for both workflow files (environment `prod`)
- [ ] Manually trigger `Publish OAuth2Client Package` via workflow_dispatch and confirm the `NuGet login` step succeeds and push completes
- [ ] Manually trigger `Publish OAuth2 Package` via workflow_dispatch and confirm the same

Jira: https://xero.atlassian.net/browse/XAPI-2340

🤖 Generated with [Claude Code](https://claude.com/claude-code)