### PR TITLE
[XAPI-2340] Open a PR for OAuth2Client version bumps instead of pushing to master

### DIFF
--- a/.github/workflows/publish-Oauth2Client-package.yml
+++ b/.github/workflows/publish-Oauth2Client-package.yml
@@ -165,15 +165,13 @@ jobs:
         VERSION="${{steps.calc_version.outputs.version}}"
         BRANCH="bump-oauth2client-v${VERSION}"
 
-        # master is a protected branch (requires PR + status checks), so the
-        # version bump has to land via PR rather than a direct push.
+        # Open a PR for the version bump; master requires one.
         git checkout -b "$BRANCH"
         git add ./Xero.NetStandard.OAuth2Client/Xero.NetStandard.OAuth2Client.csproj
         git commit -m "Bump OAuth2Client version to ${VERSION}"
         git push origin "$BRANCH"
 
-        # Tags aren't covered by the branch protection rule, so this can still
-        # be pushed directly and keeps "Check for changes" working next run.
+        # Push the tag directly.
         git tag "OAuthClient-v${VERSION}"
         git push origin "OAuthClient-v${VERSION}"
 
@@ -187,8 +185,7 @@ jobs:
 
         {
           echo "## OAuth2Client version bump"
-          echo "Package \`${VERSION}\` was published to nuget.org."
-          echo "\`master\` is protected, so the version bump commit still needs to be merged:"
+          echo "Package \`${VERSION}\` was published to nuget.org. Merge the version bump PR:"
           echo ""
           echo "**➡️ [$PR_URL]($PR_URL)**"
         } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/publish-Oauth2Client-package.yml
+++ b/.github/workflows/publish-Oauth2Client-package.yml
@@ -17,6 +17,7 @@ jobs:
       # Used to conditionally run publish steps and notifications
       client_version: ${{steps.calc_version.outputs.version}}
       should_publish: ${{steps.check_changes.outputs.has_changes}}
+      version_bump_pr_url: ${{steps.commit_tag_and_pr.outputs.pr_url}}
 
     permissions:
       contents: write
@@ -154,22 +155,43 @@ jobs:
       run: dotnet nuget push ./Xero.NetStandard.OAuth2Client/bin/Release/Xero.NetStandard.OAuth2Client.${{steps.calc_version.outputs.version}}.nupkg --api-key ${{ steps.nuget_login.outputs.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json
       working-directory: Xero-NetStandard
 
-    - name: Commit, Push and Tag
+    - name: Commit, Tag and Open PR
       if: steps.check_changes.outputs.has_changes == 'true'
+      id: commit_tag_and_pr
       run: |
         git config user.name "github-actions[bot]"
         git config user.email "github-actions[bot]@users.noreply.github.com"
-        
-        # Commit the version bump
+
+        VERSION="${{steps.calc_version.outputs.version}}"
+        BRANCH="bump-oauth2client-v${VERSION}"
+
+        # master is a protected branch (requires PR + status checks), so the
+        # version bump has to land via PR rather than a direct push.
+        git checkout -b "$BRANCH"
         git add ./Xero.NetStandard.OAuth2Client/Xero.NetStandard.OAuth2Client.csproj
-        git commit -m "Bump OAuth2Client version to ${{steps.calc_version.outputs.version}}"
-        
-        # Push the commit to master
-        git push origin HEAD:master
-        
-        # Create and push the tag
-        git tag "OAuthClient-v${{steps.calc_version.outputs.version}}"
-        git push origin "OAuthClient-v${{steps.calc_version.outputs.version}}"
+        git commit -m "Bump OAuth2Client version to ${VERSION}"
+        git push origin "$BRANCH"
+
+        # Tags aren't covered by the branch protection rule, so this can still
+        # be pushed directly and keeps "Check for changes" working next run.
+        git tag "OAuthClient-v${VERSION}"
+        git push origin "OAuthClient-v${VERSION}"
+
+        PR_URL=$(gh pr create \
+          --base master \
+          --head "$BRANCH" \
+          --title "Bump OAuth2Client version to ${VERSION}" \
+          --body "Automated version bump for OAuth2Client \`${VERSION}\`, already published to nuget.org by this workflow run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}")
+
+        echo "pr_url=$PR_URL" >> "$GITHUB_OUTPUT"
+
+        {
+          echo "## OAuth2Client version bump"
+          echo "Package \`${VERSION}\` was published to nuget.org."
+          echo "\`master\` is protected, so the version bump commit still needs to be merged:"
+          echo ""
+          echo "**➡️ [$PR_URL]($PR_URL)**"
+        } >> "$GITHUB_STEP_SUMMARY"
       working-directory: Xero-NetStandard
       env:
         GH_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
## Summary
- Found while testing the Trusted Publishing switch (#663): the `Commit, Push and Tag` step in `publish-Oauth2Client-package.yml` pushes directly to `master`, but `master` is a protected branch requiring a PR + the `build-test-lint` status check. Every prior "successful" run of this workflow had actually short-circuited before this step (no changes detected), so this direct push has likely never worked when there were real changes to publish. See run [31353584005](https://github.com/XeroAPI/Xero-NetStandard/actions/runs/31353584005/job/93348879507) for the failure.
- Confirmed the default `GITHUB_TOKEN` can't be granted bypass on the ruleset — bypass actors are limited to specific roles, teams, installed GitHub Apps, or Dependabot, not the generic Actions token identity.
- Replaced the direct push with: commit the version bump on a new branch → push the branch → tag the commit (tags aren't covered by the branch ruleset) → open a PR into `master` → surface the PR URL in the job's `$GITHUB_STEP_SUMMARY`.

## Prerequisite to verify
- Actions must be allowed to create pull requests on this repo: **Settings → Actions → General → Workflow permissions → "Allow GitHub Actions to create and approve pull requests"**. If this is off, `gh pr create` in the new step will fail.

## Test plan
- [x] Confirm the "Allow GitHub Actions to create and approve pull requests" setting is enabled
- [ ] Manually trigger `Publish OAuth2Client Package` with a real OAuth2Client change and confirm the new step opens a PR and the step summary links to it
- [ ] Merge the resulting PR and confirm the tag/version stay in sync for the next run

Jira: https://xero.atlassian.net/browse/XAPI-2340

🤖 Generated with [Claude Code](https://claude.com/claude-code)