### PR TITLE
[XAPI-2340] Bump OAuth2Client version to 1.6.1

### DIFF
--- a/Xero.NetStandard.OAuth2Client/Xero.NetStandard.OAuth2Client.csproj
+++ b/Xero.NetStandard.OAuth2Client/Xero.NetStandard.OAuth2Client.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <PackageId>Xero.NetStandard.OAuth2Client</PackageId>
-    <Version>1.6.0</Version>
+    <Version>1.6.1</Version>
     <Authors>Xero</Authors>
     <Company>Xero</Company>
     <PackageLicenseUrl>https://github.com/XeroAPI/Xero-NetStandard/</PackageLicenseUrl>


### PR DESCRIPTION
## Summary
- 1.6.1 was published to nuget.org, but the version bump commit and tag never landed in the repo.
- This PR bumps `Xero.NetStandard.OAuth2Client.csproj` to `1.6.1` to match. The `OAuthClient-v1.6.1` tag has already been pushed against this branch's commit.

## What's left
- [ ] Merge this PR so `master`'s csproj version matches nuget.org and the next scheduled publish run calculates `1.6.2` correctly.

Jira: https://xero.atlassian.net/browse/XAPI-2340

🤖 Generated with [Claude Code](https://claude.com/claude-code)